### PR TITLE
Turn off husky in ci and trigger release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read # for checkout
 
+env:
+  HUSKY: 0
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
**Summary**

- Husky is causing the publish build step to exit with non zero. Turning husky off in ci
