### PR TITLE
Web 8741 Ensure padding between prehead and title in banners

### DIFF
--- a/src/components/HeroBanner/_heroBanner.scss
+++ b/src/components/HeroBanner/_heroBanner.scss
@@ -94,10 +94,6 @@
             font-size: 2.375rem;
         }
 
-        @media (max-width: 28.8125rem) { 
-            margin: 0;
-        }
-
         span {
             font-size: 1.625rem;
         }


### PR DESCRIPTION
Closes [WEB-8741](https://phillipsauctions.atlassian.net/browse/WEB-8741)

**Summary**

- Fix for margin issue on mobile. Removed unnecessary media query affecting pre head and post head margins

**Change List (describe the changes made to the files)**

- Removed media query (_heroBanner.scss)

**Acceptance Test (how to verify the PR)**

- Check margin spacing for pre head and post head on mobile screen size

**Regression Test (how to make sure this PR doesn't break old functionality)**

- N/A

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `phillips` class prefix is using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] All strings should be translatable.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
- [ ] Make sure all commits messages follow convention and are appropriate for the changes
