### PR TITLE
Add commonjs build to our package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@phillips/seldon",
   "version": "1.8.0",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,18 +54,28 @@ export default defineConfig({
       // Could also be a dictionary or array of multiple entry points
       entry: ['index.ts'],
       name: 'seldon',
-      formats: ['es'],
+      formats: ['es', 'cjs'],
     },
 
     rollupOptions: {
       input: 'src/index.ts',
-      output: {
+      output: [
+        {
         dir: 'dist',
+        format: 'es',
         preserveModules: true,
         preserveModulesRoot: 'src',
         chunkFileNames: '[name].js',
         entryFileNames: '[name].js',
       },
+      {
+        dir: 'dist',
+        format: 'cjs',
+        preserveModulesRoot: 'src',
+        chunkFileNames: '[name].cjs',
+        entryFileNames: '[name].cjs',
+      },
+    ],
       // make sure to externalize deps that shouldn't be bundled
       // into your library
       external: [...Object.keys(packageJson.peerDependencies)],


### PR DESCRIPTION


**Summary**

Added a common js build option to our config for issues I was having in the Remix project. 

**Change List (describe the changes made to the files)**

- Added a section to vite.config.js to build a cjs version
- updated Packages.json `main` field to point to the cjs version.

**Acceptance Test (how to verify the PR)**

- tests here

**Regression Test (how to make sure this PR doesn't break old functionality)**

- We need to test this on Phillips Web just to be sure we are not breaking the import in that project. 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `phillips` class prefix is using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] All strings should be translatable.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
- [ ] Make sure all commits messages follow convention and are appropriate for the changes
