### PR TITLE
fix: tweak build settings to stop bundling classnames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "@phillips/seldon",
-  "version": "1.7.1",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@phillips/seldon",
-      "version": "1.7.1",
+      "version": "1.9.0",
       "dependencies": {
+        "classnames": "^2.5.1",
         "flatpickr": "^4.6.13",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -34,7 +35,6 @@
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",
         "@vitejs/plugin-react": "^4.0.0",
-        "classnames": "^2.3.2",
         "color": "^4.2.3",
         "eslint": "^8.38.0",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -10487,10 +10487,9 @@
       "dev": true
     },
     "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "dev": true
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@phillips/seldon",
   "version": "1.9.0",
   "type": "module",
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -33,6 +33,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "classnames": "^2.5.1",
     "flatpickr": "^4.6.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -59,7 +60,6 @@
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "@vitejs/plugin-react": "^4.0.0",
-    "classnames": "^2.3.2",
     "color": "^4.2.3",
     "eslint": "^8.38.0",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,7 +54,6 @@ export default defineConfig({
       // Could also be a dictionary or array of multiple entry points
       entry: ['index.ts'],
       name: 'seldon',
-      formats: ['es', 'cjs'],
     },
 
     rollupOptions: {
@@ -68,17 +67,17 @@ export default defineConfig({
         chunkFileNames: '[name].js',
         entryFileNames: '[name].js',
       },
-      {
-        dir: 'dist',
-        format: 'cjs',
-        preserveModulesRoot: 'src',
-        chunkFileNames: '[name].cjs',
-        entryFileNames: '[name].cjs',
-      },
-    ],
+      // {
+      //   dir: 'dist',
+      //   format: 'cjs',
+      //   preserveModulesRoot: 'src',
+      //   chunkFileNames: '[name].cjs',
+      //   entryFileNames: '[name].cjs',
+      // },
+      ],
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: [...Object.keys(packageJson.peerDependencies)],
+      external: [...Object.keys(packageJson.peerDependencies), ...Object.keys(packageJson.dependencies)],
       plugins: [
         copy({
           hook: 'writeBundle',


### PR DESCRIPTION
Closes #

**Summary**

-  tweak build settings to stop bundling classnames

**Change List (describe the changes made to the files)**

- swapped classnames from a devDep to a depenedency in package.json
- listed deps as external in our build config in vite.config.ts

We will need to test this release for regressions in phillips-public

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `phillips` class prefix is using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] All strings should be translatable.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
- [ ] Make sure all commits messages follow convention and are appropriate for the changes
