### PR TITLE
Undo build config changes that were unnecessary 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,14 @@
 ## [1.9.2](https://github.com/PhillipsAuctionHouse/seldon/compare/v1.9.1...v1.9.2) (2024-01-21)
 
-
 ### Bug Fixes
 
-* still troublshooting build ([486dfc7](https://github.com/PhillipsAuctionHouse/seldon/commit/486dfc7c6baa228dc56eb158c1e89459485fd57a))
+- still troublshooting build ([486dfc7](https://github.com/PhillipsAuctionHouse/seldon/commit/486dfc7c6baa228dc56eb158c1e89459485fd57a))
 
 ## [1.9.1](https://github.com/PhillipsAuctionHouse/seldon/compare/v1.9.0...v1.9.1) (2024-01-20)
 
-
 ### Bug Fixes
 
-* tweak build settings to stop bundling classnames ([c26106c](https://github.com/PhillipsAuctionHouse/seldon/commit/c26106cd74a3aab4e3e09bb72611f34fc84ed20f))
+- tweak build settings to stop bundling classnames ([c26106c](https://github.com/PhillipsAuctionHouse/seldon/commit/c26106cd74a3aab4e3e09bb72611f34fc84ed20f))
 
 # [1.9.0](https://github.com/PhillipsAuctionHouse/seldon/compare/v1.8.0...v1.9.0) (2024-01-19)
 

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "@phillips/seldon",
   "version": "1.9.2",
   "type": "module",
-  "main": "./dist/index.mjs",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.mjs"
+        "default": "./dist/index.js"
       }
     },
     "./dist/": {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,7 +5,7 @@
 @import './typography';
 // ⚛️ Components
 @import 'components/Button/button';
-@import 'components/DatePicker/datePicker';
+// @import 'components/DatePicker/datePicker';
 @import 'components/Header/header';
 @import 'components/HeroBanner/heroBanner';
 @import 'components/Input/input';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,9 +48,6 @@ export default defineConfig({
     ],
   },
 
-  optimizeDeps: {
-    include: ['classnames'],
-  },
   build: {
     minify: true,
     reportCompressedSize: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
   },
 
   optimizeDeps: {
-    include: ["classnames"],
+    include: ['classnames'],
   },
   build: {
     minify: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,15 +47,18 @@ export default defineConfig({
       },
     ],
   },
+
+  optimizeDeps: {
+    include: ["classnames"],
+  },
   build: {
     minify: true,
     reportCompressedSize: true,
     lib: {
       // Could also be a dictionary or array of multiple entry points
-      entry: ['index.ts'],
+      entry: ['src/index.ts'],
       name: 'seldon',
     },
-
     rollupOptions: {
       input: 'src/index.ts',
       output: [
@@ -64,16 +67,9 @@ export default defineConfig({
           format: 'es',
           preserveModules: true,
           preserveModulesRoot: 'src',
-          chunkFileNames: '[name].mjs',
-          entryFileNames: '[name].mjs',
+          chunkFileNames: '[name].js',
+          entryFileNames: '[name].js',
         },
-        // {
-        //   dir: 'dist',
-        //   format: 'cjs',
-        //   preserveModulesRoot: 'src',
-        //   chunkFileNames: '[name].cjs',
-        //   entryFileNames: '[name].cjs',
-        // },
       ],
       // make sure to externalize deps that shouldn't be bundled
       // into your library


### PR DESCRIPTION
Closes #

**Summary**

- Previous PRs added changes to our config to deal with SSR in our remix application and the commonjs deps we ship along with this library. I was able to alter config in the remix project that should negate the need for these changes. Undoing here to ensure compatibility with the Phillips-web project. 

**Change List (describe the changes made to the files)**

- Changed `vite.config.ts` to no longer output `mjs` file
- removed the import of our datepicker sass partial as the component is not exported from this library yet.
- Changed the `package.json` to no longer reference the `.mjs` entry 

**Acceptance Test (how to verify the PR)**

As long as our checks all pass here this should be good. We need to pull in latest in Phillips-web to be sure that build still works with these changes. 


**Things to look for during review**

- [ ] Make sure all references to `phillips` class prefix is using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] All strings should be translatable.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
- [ ] Make sure all commits messages follow convention and are appropriate for the changes
