### PR TITLE
L3-432 viewings widget label rearranging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 # [1.13.0](https://github.com/PhillipsAuctionHouse/seldon/compare/v1.12.0...v1.13.0) (2024-03-20)
 
-
 ### Features
 
-* alphabetizing interface in ViewingsListCardForm ([31cb8ff](https://github.com/PhillipsAuctionHouse/seldon/commit/31cb8ff82868ac25a1dc9a7eb7716562b31d2c22))
-* filling out missing email fields from previous edits ([4ead7fd](https://github.com/PhillipsAuctionHouse/seldon/commit/4ead7fd54034bc5f6a50df234abeff2384f444d0))
-* fixing missing usage, making tests pass ([ad5064f](https://github.com/PhillipsAuctionHouse/seldon/commit/ad5064f09baf953c437a025565383a56d5aaf415))
-* updating Changelog ([28c2f10](https://github.com/PhillipsAuctionHouse/seldon/commit/28c2f10f9bd4798da86cce440e184b8d0e11b50c))
-* updating Changelog ([fa41bcc](https://github.com/PhillipsAuctionHouse/seldon/commit/fa41bcc66ba5286d27b049a0103562fb450c42ea))
-* updating Changelog ([6799bae](https://github.com/PhillipsAuctionHouse/seldon/commit/6799baeb87129caf2d0833cdfa463ba0aaa8cd24))
+- alphabetizing interface in ViewingsListCardForm ([31cb8ff](https://github.com/PhillipsAuctionHouse/seldon/commit/31cb8ff82868ac25a1dc9a7eb7716562b31d2c22))
+- filling out missing email fields from previous edits ([4ead7fd](https://github.com/PhillipsAuctionHouse/seldon/commit/4ead7fd54034bc5f6a50df234abeff2384f444d0))
+- fixing missing usage, making tests pass ([ad5064f](https://github.com/PhillipsAuctionHouse/seldon/commit/ad5064f09baf953c437a025565383a56d5aaf415))
+- updating Changelog ([28c2f10](https://github.com/PhillipsAuctionHouse/seldon/commit/28c2f10f9bd4798da86cce440e184b8d0e11b50c))
+- updating Changelog ([fa41bcc](https://github.com/PhillipsAuctionHouse/seldon/commit/fa41bcc66ba5286d27b049a0103562fb450c42ea))
+- updating Changelog ([6799bae](https://github.com/PhillipsAuctionHouse/seldon/commit/6799baeb87129caf2d0833cdfa463ba0aaa8cd24))
 
 # [1.12.0](https://github.com/PhillipsAuctionHouse/seldon/compare/v1.11.0...v1.12.0) (2024-03-14)
 

--- a/src/components/ViewingsList/ViewingsListCardForm.tsx
+++ b/src/components/ViewingsList/ViewingsListCardForm.tsx
@@ -186,10 +186,10 @@ const ViewingsListCardForm = ({
   previewHours1Label = 'Hours1',
   previewHours2,
   previewHours2Label = 'Hours2',
-  previewLabel = "Label ('Preview', 'Opening NIght', etc)",
+  previewLabel = "Label ('Preview', 'Opening Night', etc)",
   previewLabelValue,
   previewOn = 'false',
-  previewToggleLabel = 'Preview/ Reception',
+  previewToggleLabel = 'Additional Hours',
   viewingLabel = "Label ('Open to public')",
   viewingLabelValue,
   viewingDates,
@@ -207,15 +207,6 @@ const ViewingsListCardForm = ({
   }, [previewOn]);
   return (
     <>
-      <Input
-        id={`viewingLabel-${id}`}
-        name="viewingLabelValue"
-        defaultValue={viewingLabelValue}
-        labelText={viewingLabel}
-        size="sm"
-        invalid={invalidFields?.viewingLabelValue}
-        invalidText={invalidFields?.viewingLabelValue}
-      />
       <Input
         id={`viewingDates-${id}`}
         name="viewingDates"
@@ -242,6 +233,15 @@ const ViewingsListCardForm = ({
         size="sm"
         invalid={invalidFields?.viewingHours2}
         invalidText={invalidFields?.viewingHours2}
+      />
+      <Input
+        id={`viewingLabel-${id}`}
+        name="viewingLabelValue"
+        defaultValue={viewingLabelValue}
+        labelText={viewingLabel}
+        size="sm"
+        invalid={invalidFields?.viewingLabelValue}
+        invalidText={invalidFields?.viewingLabelValue}
       />
 
       <Input


### PR DESCRIPTION
Closes #L3-432

**Summary**

 - Moved Label field for primary viewing under 'hours 2'
 - Renamed "Preview" toggle default to "Additional Viewings"

**Change List (describe the changes made to the files)**

`ViewingsListCardForm.tsx`

**Acceptance Test (how to verify the PR)**

- See that primary viewings label was moved
- See that Preview toggle label now reads "Additional Viewings"

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `phillips` class prefix is using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] All strings should be translatable.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
- [ ] Make sure all commits messages follow convention and are appropriate for the changes
