### PR TITLE
L3-382 - moving label fields back to top

### DIFF
--- a/src/components/ViewingsList/ViewingsListCardForm.tsx
+++ b/src/components/ViewingsList/ViewingsListCardForm.tsx
@@ -208,6 +208,15 @@ const ViewingsListCardForm = ({
   return (
     <>
       <Input
+        id={`viewingLabel-${id}`}
+        name="viewingLabelValue"
+        defaultValue={viewingLabelValue}
+        labelText={viewingLabel}
+        size="sm"
+        invalid={invalidFields?.viewingLabelValue}
+        invalidText={invalidFields?.viewingLabelValue}
+      />
+      <Input
         id={`viewingDates-${id}`}
         name="viewingDates"
         defaultValue={viewingDates}
@@ -234,15 +243,6 @@ const ViewingsListCardForm = ({
         invalid={invalidFields?.viewingHours2}
         invalidText={invalidFields?.viewingHours2}
       />
-      <Input
-        id={`viewingLabel-${id}`}
-        name="viewingLabelValue"
-        defaultValue={viewingLabelValue}
-        labelText={viewingLabel}
-        size="sm"
-        invalid={invalidFields?.viewingLabelValue}
-        invalidText={invalidFields?.viewingLabelValue}
-      />
 
       <Input
         id={`previewOn-${id}`}
@@ -262,6 +262,16 @@ const ViewingsListCardForm = ({
       <div
         className={classnames(`${baseClass}__preview-set`, { [`${baseClass}__preview-set--hidden`]: !previewOnState })}
       >
+        <Input
+          id={`previewLabel-${id}`}
+          name="previewLabelValue"
+          defaultValue={previewLabelValue}
+          labelText={previewLabel}
+          size="sm"
+          invalid={invalidFields?.previewLabelValue}
+          invalidText={invalidFields?.previewLabelValue}
+          hidden={!previewOnState}
+        />
         <Input
           id={`previewDates-${id}`}
           name="previewDates"
@@ -290,16 +300,6 @@ const ViewingsListCardForm = ({
           size="sm"
           invalid={invalidFields?.previewHours2}
           invalidText={invalidFields?.previewHours2}
-          hidden={!previewOnState}
-        />
-        <Input
-          id={`previewLabel-${id}`}
-          name="previewLabelValue"
-          defaultValue={previewLabelValue}
-          labelText={previewLabel}
-          size="sm"
-          invalid={invalidFields?.previewLabelValue}
-          invalidText={invalidFields?.previewLabelValue}
           hidden={!previewOnState}
         />
       </div>


### PR DESCRIPTION
**Jira ticket**

[[L3-482](https://phillipsauctions.atlassian.net/browse/L3-382)]

**Summary**

Moving label fields back to top as before. 

**Change List (describe the changes made to the files)**

`\seldon\src\components\ViewingsList\ViewingsListCardForm.tsx`

**Acceptance Test (how to verify the PR)**

- Label fields have gloriously returned to the top of their respective sections

**Things to look for during review**

- [ ] Make sure all references to `phillips` class prefix is using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] All strings should be translatable.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
- [ ] Make sure all commits messages follow convention and are appropriate for the changes


[L3-482]: https://phillipsauctions.atlassian.net/browse/L3-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ