### PR TITLE
L3 1839 fix type exports for components

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run format
+npm run format && git add .

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -5,7 +5,7 @@ type User = {
   name: string;
 };
 
-interface HeaderProps {
+export interface HeaderProps {
   user?: User;
   onLogin?: () => void;
   onLogout?: () => void;

--- a/src/components/HeroBanner/HeroBanner.tsx
+++ b/src/components/HeroBanner/HeroBanner.tsx
@@ -1,6 +1,6 @@
 import { px } from '../../utils';
 
-interface HeroBannerProps {
+export interface HeroBannerProps {
   /**
    * informational text above the header (e.g. region label or "buy now")
    */

--- a/src/design/type-tokens/type-tokens.mdx
+++ b/src/design/type-tokens/type-tokens.mdx
@@ -34,8 +34,8 @@ consistent and scalable design system.
 - **Default**: <span className="property">font-size:</span> 3.25rem; <span className="property">
   line-height:
   </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
-text-transform:
-</span> uppercase;
+  text-transform:
+  </span> uppercase;
 - **BP1**: <span className="property">font-size:</span> 2.59rem;
 - **BP4**: <span className="property">
   font-size:
@@ -57,7 +57,7 @@ text-transform:
 
 - **Default**: <span className="property">font-size:</span> 2.44rem; <span className="property">
   line-height:
-    </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
+  </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
 text-transform:
 </span> uppercase;
 - **BP1**: <span className="property">font-size:</span> 1.83rem;
@@ -81,7 +81,7 @@ text-transform:
 
 - **Default**: <span className="property">font-size:</span> 1.95rem; <span className="property">
   line-height:
-    </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
+  </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
 text-transform:
 </span> uppercase;
 - **BP1**: <span className="property">font-size:</span> 1.46rem;
@@ -105,7 +105,7 @@ text-transform:
 
 - **Default**: <span className="property">font-size:</span> 1.56rem; <span className="property">
   line-height:
-    </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
+  </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
 text-transform:
 </span> uppercase;
 - **BP1**: <span className="property">font-size:</span> 1.17rem;
@@ -129,7 +129,7 @@ text-transform:
 
 - **Default**: <span className="property">font-size:</span> 1.56rem; <span className="property">
   line-height:
-    </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
+  </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
 text-transform:
 </span> uppercase;
 - **BP1**: <span className="property">font-size:</span> 0.94rem;
@@ -160,7 +160,7 @@ text-transform:
 
 - **Default**: <span className="property">font-size:</span> 2.44rem; <span className="property">
   line-height:
-    </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
+  </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
 text-transform:
 </span> uppercase;
 - **BP1**: <span className="property">font-size:</span> 1.83rem;
@@ -184,7 +184,7 @@ text-transform:
 
 - **Default**: <span className="property">font-size:</span> 1.95rem; <span className="property">
   line-height:
-    </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
+  </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
 text-transform:
 </span> uppercase;
 - **BP1**: <span className="property">font-size:</span> 1.46rem;
@@ -208,7 +208,7 @@ text-transform:
 
 - **Default**: <span className="property">font-size:</span> 1.56rem; <span className="property">
   line-height:
-    </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
+  </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
 text-transform:
 </span> uppercase;
 - **BP1**: <span className="property">font-size:</span> 1.17rem;
@@ -232,7 +232,7 @@ text-transform:
 
 - **Default**: <span className="property">font-size:</span> 1.56rem; <span className="property">
   line-height:
-    </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
+  </span> 1.25; <span className="property">font-weight:</span> 400; <span className="property">
 text-transform:
 </span> uppercase;
 - **BP1**: <span className="property">font-size:</span> 0.94rem;

--- a/src/docs/CONTRIBUTING.md
+++ b/src/docs/CONTRIBUTING.md
@@ -85,7 +85,7 @@ If you follow the convention seen in existing stories the documentation is auto 
 This is a typescript project so all props are defined using [interfaces](https://www.typescriptlang.org/docs/handbook/2/objects.html). Be sure to add comments as these become the documentation for the component in our storybook. Default props should be written as part of the prop destructing.
 
 ```js
-interface ButtonProps {
+export interface ButtonProps {
   /**
    * Is this the principal call to action on the page?
    */
@@ -128,6 +128,14 @@ const Button = ({
 };
 ```
 
+## Exporting components
+
+After adding a component make sure that the component is exported from the main `index.ts` file. This will allow the component to be imported from the main package. Please also export any Typescript types that should be available to consumers of the package.
+
+```js
+export { Button, type ButtonProps } from './components/Button/Button';
+```
+
 ## Testing
 
 Unit test must be written for all JavaScript files. We utlize [`Jest.js`](https://jestjs.io/) and the [`@testing-library`](https://testing-library.com/docs/react-testing-library/intro) packages to author test.
@@ -156,3 +164,21 @@ the code coverage threshold to get around this constraint._
 
 To understand what lines of code are NOT covered by the current testcases, open
 the coverage/index.html file in a browser and investigate.
+
+## Testing changes in downstream consumers
+
+Often times changes to the library are being made to add features to an application. To test these changes you can link the library to the consuming application. This is done by running the following commands to add the library to the global npm registry:
+
+```sh
+npm run build
+cd dist
+npm link
+```
+
+Then you will point the application to the `seldon` published in the global npm registry not the one installed locally in `application/node_modules`. To link the application in to the global npm registry run the following command in the application directory:
+
+```sh
+npm link "@phillips/seldon"
+```
+
+Future rebuilds of the library will be reflected in the application without having to publish the library again to the npm registry. If you perform a full `npm install` or add a new library in the consuming application you will need to re-link the library.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,16 @@
 // ⚛️ Components
-export { default as Button } from './components/Button/Button';
-export { default as ErrorBoundary } from './components/ErrorBoundary/ErrorBoundary';
-// export { default as DatePicker } from './components/DatePicker/DatePicker';
-export { default as Grid } from './components/Grid/Grid';
-export { default as Header } from './components/Header/Header';
-export { default as HeroBanner } from './components/HeroBanner/HeroBanner';
-export { default as Input } from './components/Input/Input';
-export { default as Select } from './components/Select/Select';
-export { default as ViewingsList } from './components/ViewingsList/ViewingsList';
-export { default as StatefulViewingsList } from './components/ViewingsList/StatefulViewingsList';
+export { default as Button, type ButtonProps } from './components/Button/Button';
+export { default as ErrorBoundary, type ErrorBoundaryProps } from './components/ErrorBoundary/ErrorBoundary';
+// export { default as DatePicker, type DatePickerProps } from './components/DatePicker/DatePicker';
+export { default as Grid, type GridProps } from './components/Grid/Grid';
+export { default as Header, type HeaderProps } from './components/Header/Header';
+export { default as HeroBanner, type HeroBannerProps } from './components/HeroBanner/HeroBanner';
+export { default as Input, type InputProps } from './components/Input/Input';
+export { default as Select, type SelectProps } from './components/Select/Select';
+export { default as ViewingsList, type ViewingsListProps } from './components/ViewingsList/ViewingsList';
+export {
+  default as StatefulViewingsList,
+  type StatefulViewingsListProps,
+} from './components/ViewingsList/StatefulViewingsList';
 // 📑 Pages
 export { default as Page } from './pages/Page';


### PR DESCRIPTION
**Jira ticket**

[L3-1839](https://phillipsauctions.atlassian.net/browse/L3-1839)

**Summary**

Consumers need to be able to import Typescript types if they need to reuse the types in their own types.

**Change List (describe the changes made to the files)**

- chore(pre-commit): have any automatically formatted files delivered as part of the commit
- fix(components/*): always export the interfaces from the component
- fix(index): export all the important types from the root of the package.

**Acceptance Test (how to verify the PR)**

- Follow the steps in the README.MD to build seldon and link the new version to the consuming application.  It can be `phillips-public-remix` or `phillips-public`
- From the consuming application try and import one of the Typescript interfaces.
```javascript
import { Button, type ButtonProps } from '@phillips/seldon';
```

**Regression Test**
N/A

**Evidence of testing**

- No error shown here: 
<img width="455" alt="image" src="https://github.com/PhillipsAuctionHouse/seldon/assets/6663002/af09e8da-e99a-46de-be3b-47a48bfd689a">


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `phillips` class prefix is using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] All strings should be translatable.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] Changes or new components should either write new or update existing documentation.
- [ ] PR should link and close out an existing issue
- [ ] Make sure all commits messages follow convention and are appropriate for the changes
