### PR TITLE
Chore: L3-2064 Change Seldon prettier config to be compatible with Phillips-public deprecated sass compiler

### DIFF
--- a/src/components/Grid/_grid.scss
+++ b/src/components/Grid/_grid.scss
@@ -9,11 +9,11 @@
   &__container--has-margins {
     margin: 0 $spacing-medium;
 
-    @media (width >= 1401px) {
+    @media (min-width: 1401px) {
       margin: 0 $spacing-large;
     }
 
-    @media (width >= 1801px) {
+    @media (min-width: 1801px) {
       margin: 0 $spacing-xl;
     }
   }

--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -1,6 +1,6 @@
 .storybook-header {
   align-items: center;
-  border-bottom: 1px solid rgb(0 0 0 / 10%);
+  border-bottom: 1px solid rgba(0, 0, 0, 10%);
   display: flex;
   font-family: Montserrat, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   justify-content: space-between;

--- a/src/components/HeroBanner/_heroBanner.scss
+++ b/src/components/HeroBanner/_heroBanner.scss
@@ -13,7 +13,7 @@
   padding: 1rem;
   width: 100%;
 
-  @media (width <= 28.8125rem) {
+  @media (max-width: 28.8125rem) {
     align-items: center;
     align-self: stretch;
     background: $pure-black;
@@ -70,11 +70,11 @@
     font-size: 0.75rem;
     gap: 1.875rem;
 
-    @media (width >= 28.8125rem) {
+    @media (min-width: 28.8125rem) {
       font-size: 0.875rem;
     }
 
-    @media (width <= 28.8125rem) {
+    @media (max-width: 28.8125rem) {
       align-items: center;
       flex-direction: column;
       gap: 1rem;
@@ -90,7 +90,7 @@
     margin: 1.875rem 0;
     text-align: center;
 
-    @media (width >= 28.8125rem) {
+    @media (min-width: 28.8125rem) {
       font-size: 2.375rem;
     }
 

--- a/src/components/Input/_input.scss
+++ b/src/components/Input/_input.scss
@@ -97,7 +97,7 @@ $lg: #{$px}-input--lg;
     }
 
     .#{$px}-input__input {
-      background-color: rgb(239 239 239 / 30%);
+      background-color: rgba(239, 239, 239, 30%);
     }
   }
 

--- a/src/components/Toggle/_toggle.scss
+++ b/src/components/Toggle/_toggle.scss
@@ -30,7 +30,7 @@ $lg: #{$px}-input--lg;
     }
 
     &::before {
-      background-color: rgb(0 0 0 / 40%);
+      background-color: rgba(0, 0, 0, 40%);
       border-radius: 1rem;
       height: 1rem;
       left: 0;

--- a/src/design/grid-tokens/_grid-tokens.scss
+++ b/src/design/grid-tokens/_grid-tokens.scss
@@ -15,17 +15,17 @@
     top: 0;
     transform: translate($spacing-medium, 1.5rem);
 
-    @media (width >= 961px) {
+    @media (min-width: 961px) {
       content: '@media (min-width: 961px)';
       transform: translate($spacing-medium, 2.1875rem);
     }
 
-    @media (width >= 1401px) {
+    @media (min-width: 1401px) {
       content: '@media (min-width: 1401px)';
       transform: translate($spacing-large, 2.1875rem);
     }
 
-    @media (width >= 1801px) {
+    @media (min-width: 1801px) {
       content: '@media (min-width: 1801px)';
       transform: translate($spacing-xl, 2.75rem);
     }
@@ -41,16 +41,16 @@
     transform: translate(-50%, 2.25rem);
     width: calc(100% - 1rem);
 
-    @media (width >= 961px) {
+    @media (min-width: 961px) {
       height: calc(100% - 1.75rem);
       transform: translate(-50%, 3rem);
     }
 
-    @media (width >= 1401px) {
+    @media (min-width: 1401px) {
       width: calc(100% - 3rem);
     }
 
-    @media (width >= 1801px) {
+    @media (min-width: 1801px) {
       transform: translate(-50%, 3.55rem);
       width: calc(100% - 11rem);
     }
@@ -99,7 +99,7 @@
       margin: 0 auto;
     }
 
-    @media (width <= 960px) {
+    @media (max-width: 960px) {
       .grid-example:nth-child(n + 3) {
         display: none;
       }
@@ -109,7 +109,7 @@
       }
     }
 
-    @media (width >= 960px) and (width <= 1400px) {
+    @media (min-width: 960px) and (max-width: 1400px) {
       .grid-example:nth-child(n + 5) {
         display: none;
       }
@@ -151,7 +151,7 @@
       content: 'grid-column: 1 / -1;';
     }
 
-    @media (width >= 961px) {
+    @media (min-width: 961px) {
       .grid-example__header {
         grid-column: 1 / -1;
       }
@@ -177,7 +177,7 @@
       }
     }
 
-    @media (width >= 1401px) {
+    @media (min-width: 1401px) {
       .grid-example__header {
         grid-column: 1 / -1;
       }

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -25,7 +25,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
   -webkit-overflow-scrolling: touch;
-  -webkit-tap-highlight-color: rgb(0 0 0 / 0%);
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0%);
 }
 
 /** Fonts **/

--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -22,7 +22,7 @@ $off-white: #f4f2f1;
 
 // Notification color palette
 $error-red: #f00;
-$error-pink: rgb(255 229 229 / 90%);
+$error-pink: rgba(255, 229, 229, 90%);
 $warn-yellow: #d6d141;
 $post-sale-pink: #ff0086;
 $cta-blue: #4a90e2;

--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -104,7 +104,7 @@ $body3: 'body3';
   --label-size2: 1rem;
   --label-size3: 0.75rem;
 
-  @media (width <= 960px) {
+  @media (max-width: 960px) {
     --heading-size0: 2.59rem;
     --heading-size1: 1.83rem;
     --heading-size2: 1.46rem;
@@ -118,7 +118,7 @@ $body3: 'body3';
     --label-size3: 0.56rem;
   }
 
-  @media (width >= 1801px) {
+  @media (min-width: 1801px) {
     --heading-size0: 4.06rem;
     --heading-size1: 3.05rem;
     --heading-size2: 2.44rem;
@@ -170,7 +170,7 @@ $text-badge-label-size: var(--label-size3);
   --spacing-large: 3rem;
   --spacing-xl: 6rem;
 
-  @media (width <= 960px) {
+  @media (max-width: 960px) {
     --spacing-micro: 0.19rem;
     --spacing-xsm: 0.38rem;
     --spacing-small: 0.75rem;
@@ -179,7 +179,7 @@ $text-badge-label-size: var(--label-size3);
     --spacing-xl: 4.8rem;
   }
 
-  @media (width >= 1801px) {
+  @media (min-width: 1801px) {
     --spacing-micro: 0.31rem;
     --spacing-xsm: 0.63rem;
     --spacing-small: 1.25rem;

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -11,6 +11,7 @@ module.exports = {
     'scss/dollar-variable-pattern': null,
     'scss/at-mixin-pattern': null,
     'media-feature-range-notation': 'prefix',
+    'color-function-notation': 'legacy',
     'selector-class-pattern': [
       '^[a-z]([-]?[a-z0-9]+)*(__[a-z0-9]([-]?[a-z0-9]+)*)?(--[a-z0-9]([-]?[a-z0-9]+)*)?$',
       {

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -7,10 +7,10 @@ module.exports = {
     'order/properties-alphabetical-order': true,
     // we're fine with _utils imports
     'scss/load-no-partial-leading-underscore': null,
-
     // Relax optionated naming conventions
     'scss/dollar-variable-pattern': null,
     'scss/at-mixin-pattern': null,
+    'media-feature-range-notation': 'prefix',
     'selector-class-pattern': [
       '^[a-z]([-]?[a-z0-9]+)*(__[a-z0-9]([-]?[a-z0-9]+)*)?(--[a-z0-9]([-]?[a-z0-9]+)*)?$',
       {


### PR DESCRIPTION
**Jira ticket**

[L3-2064](https://phillipsauctions.atlassian.net/browse/L3-2064)

**Summary**

Style lint was formatting sass in a way that was breaking Phillips-public deprecated sass compiler (glup-sass)
Config file was changed to prevent future sass breaking changes
Refactored code to match Phillips-public deprecated sass compiler

Legacy setting used:
color-function-notation 
media-feature-range-notation

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `phillips` class prefix is using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] PR should link and close out an existing issue
- [ ] Make sure all commits messages follow convention and are appropriate for the changes

New Components

- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file


[L3-2064]: https://phillipsauctions.atlassian.net/browse/L3-2064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ