### PR TITLE
Chore: L3-2065 Revert Nullish Coalescing Operators in Seldon

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { nullishCoalescing } from '../../utils';
 
 export interface ErrorBoundaryProps {
   /**
@@ -36,7 +37,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     // Swap out for logging service
-    this.props?.logger(error, info.componentStack ?? 'ErrorBoundary caught an error');
+    this.props?.logger(error, nullishCoalescing(info.componentStack, 'ErrorBoundary caught an error'));
   }
 
   render() {

--- a/src/components/LinkBlock/LinkBlock.tsx
+++ b/src/components/LinkBlock/LinkBlock.tsx
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import { px } from '../../utils';
 import Link, { LinkProps } from '../Link/Link';
 import { LinkVariants } from '../Link/utils';
+import { nullishCoalescing } from '../../utils';
 
 export interface LinkBlockProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Props for the Link component */
@@ -21,7 +22,7 @@ export interface LinkBlockProps extends React.HTMLAttributes<HTMLDivElement> {
 const LinkBlock = ({ linkProps, description, className: classNameProp, id, ...props }: LinkBlockProps) => {
   const baseClassName = `${px}-link-block`;
   const className = classnames(baseClassName, classNameProp);
-  const LinkComponent = linkProps.element ?? Link;
+  const LinkComponent = nullishCoalescing(linkProps.element, Link);
   const dataTestId = id ? `link-block-${id}` : `link-block`;
 
   return (

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,0 +1,16 @@
+import { nullishCoalescing } from './index.tsx';
+
+describe('nullishCoalescing', () => {
+  it('should return string', () => {
+    const testStr = nullishCoalescing(null, 'This is a string');
+    expect(testStr).toBe(null ?? 'This is a string');
+  });
+  it('should return the number 0', () => {
+    const testNum = nullishCoalescing(0, 42);
+    expect(testNum).toBe(0 ?? 42);
+  });
+  it('should return first available value', () => {
+    const testValue = nullishCoalescing(undefined, '');
+    expect(testValue).toBe(undefined ?? '');
+  });
+});

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -110,3 +110,7 @@ export function useNormalizedInputProps({
 }
 
 export const defaultYear = new Date().getFullYear();
+
+// Nullish coalescing operator '??' polyfill
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const nullishCoalescing = (a: any, b: any) => (a !== null && a !== undefined ? a : b);


### PR DESCRIPTION
**Jira ticket**

https://phillipsauctions.atlassian.net/browse/L3-2065

**Summary**

Nullish coalescing operator '??' has created an error in Phillips-public
Testing @babel/plugin-transform-nullish-coalescing-operator have not worked
Created a polyfill for Nullish coalescing operator

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] Make sure all references to `phillips` class prefix is using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit test should be written and should have a coverage of 90% or higher in all areas.
- [ ] PR should link and close out an existing issue
- [ ] Make sure all commits messages follow convention and are appropriate for the changes

New Components

- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
