### PR TITLE
feat(usermanagement)!: L3-2972 add a loading auth state

### DIFF
--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -8,6 +8,7 @@ import { LinkVariants } from '../Link/utils';
 import { px } from '../../utils';
 import UserManagement from '../UserManagement/UserManagement';
 import Search from '../Search/Search';
+import { AuthState } from '../UserManagement/types';
 
 const meta = {
   title: 'Components/Header',
@@ -20,11 +21,15 @@ const meta = {
     },
     layout: 'fullscreen',
   },
-} satisfies Meta<typeof Header>;
+  args: {
+    authState: AuthState.LoggedOut,
+  },
+  argTypes: { authState: { control: { type: 'select' }, options: Object.values(AuthState) } },
+} satisfies Meta<typeof Header & typeof UserManagement>;
 
 export default meta;
 
-export const Playground = (props: HeaderProps) => (
+export const Playground = ({ authState, ...props }: HeaderProps & { authState?: AuthState }) => (
   <div>
     <Header {...props}>
       <Navigation id={`${px}-main-nav`} backBtnLabel="← Back">
@@ -215,7 +220,10 @@ export const Playground = (props: HeaderProps) => (
               <NavigationItem navGroup="nav-link-sm" navType={LinkVariants.navLinkSm} href="#" label="Careers" />
             </NavigationList>
           </NavigationItemTrigger>
-          <UserManagement onLanguageChange={(language) => console.log('languageChange', language)} />
+          <UserManagement
+            authState={authState}
+            onLanguageChange={(language) => console.log('languageChange', language)}
+          />
         </NavigationList>
       </Navigation>
       <Search />

--- a/src/components/UserManagement/UserManagement.stories.tsx
+++ b/src/components/UserManagement/UserManagement.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import UserManagement from './UserManagement';
 import { SupportedLanguages } from '../../types/commonTypes';
+import { AuthState } from './types';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 const meta = {
@@ -26,7 +27,7 @@ export const Playground: Story = {
     onLanguageChange: (language) => console.log('Language Change', language),
     onLogin: () => console.log('Login'),
     onLogout: () => console.log('Logout'),
-    isLoggedIn: false,
+    authState: AuthState.LoggedOut,
     loginLabel: 'Login',
     logoutLabel: 'Logout',
   },
@@ -37,5 +38,6 @@ export const Playground: Story = {
         type: 'select',
       },
     },
+    authState: { control: { type: 'select' }, options: Object.values(AuthState) },
   },
 };

--- a/src/components/UserManagement/UserManagement.test.tsx
+++ b/src/components/UserManagement/UserManagement.test.tsx
@@ -3,6 +3,7 @@ import UserManagement from './UserManagement';
 import userEvent from '@testing-library/user-event';
 import { SupportedLanguages } from '../../types/commonTypes';
 import { runCommonTests } from '../../utils/testUtils';
+import { AuthState } from './types';
 
 describe('UserManagement', () => {
   runCommonTests(UserManagement, 'UserManagement');
@@ -41,7 +42,7 @@ describe('UserManagement', () => {
 
   it('calls onLogout when logout link is clicked', async () => {
     const onLogoutMock = vitest.fn();
-    render(<UserManagement isLoggedIn onLogout={onLogoutMock} />);
+    render(<UserManagement authState={AuthState.LoggedIn} onLogout={onLogoutMock} />);
     const logoutLinkElement = screen.getByText('Logout');
     await userEvent.click(logoutLinkElement);
     expect(onLogoutMock).toHaveBeenCalled();
@@ -71,8 +72,15 @@ describe('UserManagement', () => {
 
   it('displays the correct login and logout labels when isLoggedIn is true', () => {
     const logoutLabel = 'Sign Out';
-    render(<UserManagement isLoggedIn logoutLabel={logoutLabel} />);
+    render(<UserManagement authState={AuthState.LoggedIn} logoutLabel={logoutLabel} />);
     const logoutLinkElement = screen.getByText(logoutLabel);
     expect(logoutLinkElement).toBeInTheDocument();
+  });
+  it('AuthState not loaded does not show logout or login text', () => {
+    render(<UserManagement authState={AuthState.Loading} />);
+    const logoutLinkElement = screen.queryByText('Logout');
+    expect(logoutLinkElement).not.toBeInTheDocument();
+    const loginLinkElement = screen.queryByText('Login');
+    expect(loginLinkElement).not.toBeInTheDocument();
   });
 });

--- a/src/components/UserManagement/UserManagement.tsx
+++ b/src/components/UserManagement/UserManagement.tsx
@@ -45,23 +45,25 @@ const UserManagement = ({
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'UserManagement');
   const languageLabel = languageOptions.find((option) => option.value === currentLanguage)?.label ?? 'English';
   const AccountDetailsComponent = accountDetailsLink ?? 'a';
+  const isLoggedIn = authState === AuthState.LoggedIn;
+  const shouldShowAccountDetails = authState !== AuthState.Loading;
+
   const handleLanguageChange = (language: SupportedLanguages) => {
     (document.activeElement as HTMLElement)?.blur();
     onLanguageChange(language);
   };
-
   return (
     <div {...commonProps} className={classnames(baseClassName, className)} {...props}>
       <ul className={`${baseClassName}__account-wrapper`}>
-        {authState !== AuthState.Loading && (
+        {shouldShowAccountDetails && (
           <>
             <AccountDetailsComponent>
               <AccountCircle className={`${baseClassName}__account-icon`} />
             </AccountDetailsComponent>
             <NavigationItem
               className={`${baseClassName}__login`}
-              onClick={authState === AuthState.LoggedIn ? onLogout : onLogin}
-              label={authState === AuthState.LoggedIn ? logoutLabel : loginLabel}
+              onClick={isLoggedIn ? onLogout : onLogin}
+              label={isLoggedIn ? logoutLabel : loginLabel}
             />
           </>
         )}

--- a/src/components/UserManagement/UserManagement.tsx
+++ b/src/components/UserManagement/UserManagement.tsx
@@ -8,12 +8,16 @@ import NavigationItem from '../Navigation/NavigationItem/NavigationItem';
 import { LinkProps } from '../Link/Link';
 import { SupportedLanguages } from '../../types/commonTypes';
 import classnames from 'classnames';
+import { AuthState } from './types';
 
 export interface UserManagementProps extends React.HTMLAttributes<HTMLDivElement> {
   languageOptions?: { label: string; value: SupportedLanguages }[];
   currentLanguage?: SupportedLanguages;
   onLanguageChange?: (language: SupportedLanguages) => void;
-  isLoggedIn?: boolean;
+  /**
+   * The authentication state for the current user
+   */
+  authState?: AuthState;
   onLogin?: () => void;
   onLogout?: () => void;
   accountDetailsLink?: React.ElementType<LinkProps>;
@@ -31,9 +35,9 @@ const UserManagement = ({
     { label: '中文', value: SupportedLanguages.zh },
   ],
   onLanguageChange = noOp,
-  isLoggedIn = false,
   onLogin = noOp,
   onLogout = noOp,
+  authState = AuthState.LoggedOut,
   loginLabel = 'Login',
   logoutLabel = 'Logout',
   ...props
@@ -49,16 +53,18 @@ const UserManagement = ({
   return (
     <div {...commonProps} className={classnames(baseClassName, className)} {...props}>
       <ul className={`${baseClassName}__account-wrapper`}>
-        {isLoggedIn && (
-          <AccountDetailsComponent>
-            <AccountCircle className={`${baseClassName}__account-icon`} />
-          </AccountDetailsComponent>
+        {authState !== AuthState.Loading && (
+          <>
+            <AccountDetailsComponent>
+              <AccountCircle className={`${baseClassName}__account-icon`} />
+            </AccountDetailsComponent>
+            <NavigationItem
+              className={`${baseClassName}__login`}
+              onClick={authState === AuthState.LoggedIn ? onLogout : onLogin}
+              label={authState === AuthState.LoggedIn ? logoutLabel : loginLabel}
+            />
+          </>
         )}
-        <NavigationItem
-          className={`${baseClassName}__login`}
-          onClick={isLoggedIn ? onLogout : onLogin}
-          label={isLoggedIn ? logoutLabel : loginLabel}
-        />
       </ul>
       <NavigationItemTrigger className={`${baseClassName}__language`} label={languageLabel}>
         <NavigationList id={`${px}-langauge-selection-list`} className={`${baseClassName}__language__selections`}>

--- a/src/components/UserManagement/_userManagement.scss
+++ b/src/components/UserManagement/_userManagement.scss
@@ -78,6 +78,10 @@
   }
 
   .#{$px}-nav__item {
+    > a {
+      padding: 0.5rem;
+    }
+
     &:hover,
     &:focus,
     &:focus-within {

--- a/src/components/UserManagement/types.ts
+++ b/src/components/UserManagement/types.ts
@@ -1,0 +1,8 @@
+export enum AuthState {
+  /** The authentication state hasn't loaded */
+  Loading = 'Loading',
+  /** A user is logged in */
+  LoggedIn = 'LoggedIn',
+  /** LoggedOut: There is no logged in user. */
+  LoggedOut = 'LoggedOut',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,5 +51,6 @@ export {
 export * from './components/Text';
 export * from './components/Accordion';
 export { default as UserManagement, type UserManagementProps } from './components/UserManagement/UserManagement';
+export { AuthState } from './components/UserManagement/types';
 export * from './types/commonTypes';
 export { Breadcrumb, type BreadcrumbProps } from './components/Breadcrumb';


### PR DESCRIPTION
BREAKING CHANGE: The  `UserManagement` `isLoggedIn` property has been replaced with the `authState` property

**Jira ticket**

[L3-2972](https://phillipsauctions.atlassian.net/browse/L3-2972)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/75eff643-0379-464c-b4bf-2e3e1a3e92c8) | ![image](https://github.com/user-attachments/assets/197f9c7c-6e3c-4fba-b79a-c38f7f2aec65) |

**Summary**

Because of CDN caching requirements, we need for our UserManagement panels LoggedIn/LoggedOut state to be determined client-side only after JavaScript hydrates.  This means we need to add a "Loading" state to the UserManagement panel.

**Change List (describe the changes made to the files)**

- change(UserManagement): Switch `isLoggedIn` to `authState` enum so more than 2 states can be used
- change(userManagement.scss): fix the items so that their click target doesn't extend past the top area

**Acceptance Test (how to verify the PR)**

- Go to the Header and UserManagement stories
- Change the authState property and verify that the section hides while it is loading.

**Regression Test**

- N/A

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `styles.scss` file.


[L3-2972]: https://phillipsauctions.atlassian.net/browse/L3-2972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ