### PR TITLE
fix(styles): L3-3127 need to import fonts from the main componentStyles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,6 @@ storybook-static
 coverage
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Run Vitest",
+        "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+        "args": ["run"],
+        "cwd": "${workspaceFolder}",
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen"
+      }
+    ]
+  }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "jest.enable": false,
+    "vitest.configSearchPatternExclude": "{**/node_modules/**,**/.*/**,**/*.d.ts,vite.config.ts.timestamp*}"
+}

--- a/src/componentStyles.scss
+++ b/src/componentStyles.scss
@@ -3,6 +3,8 @@
 // @TODO: reset styles when we can do a site wide regressions QA in phillips-public
 // @use 'reset';
 
+@use '#scss/typography';
+
 // ⚛️ Components
 @use 'components/Button/button';
 @use 'components/IconButton/iconButton';

--- a/src/componentStyles.scss
+++ b/src/componentStyles.scss
@@ -3,7 +3,7 @@
 // @TODO: reset styles when we can do a site wide regressions QA in phillips-public
 // @use 'reset';
 
-@use '#scss/typography';
+@use '#scss/typography' as *;
 
 // ⚛️ Components
 @use 'components/Button/button';

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export {
   type StatefulViewingsListProps,
 } from './components/ViewingsList/StatefulViewingsList';
 export * from './components/Text';
-export * from './components/HTMLParser';
+// export * from './components/HTMLParser';
 export * from './components/Accordion';
 export { default as UserManagement, type UserManagementProps } from './components/UserManagement/UserManagement';
 export { AuthState } from './components/UserManagement/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export {
   type StatefulViewingsListProps,
 } from './components/ViewingsList/StatefulViewingsList';
 export * from './components/Text';
+export * from './components/HTMLParser';
 export * from './components/Accordion';
 export { default as UserManagement, type UserManagementProps } from './components/UserManagement/UserManagement';
 export { AuthState } from './components/UserManagement/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,6 @@ export {
   type StatefulViewingsListProps,
 } from './components/ViewingsList/StatefulViewingsList';
 export * from './components/Text';
-export * from './components/HTMLParser';
 export * from './components/Accordion';
 export { default as UserManagement, type UserManagementProps } from './components/UserManagement/UserManagement';
 export { AuthState } from './components/UserManagement/types';

--- a/src/scss/_allPartials.scss
+++ b/src/scss/_allPartials.scss
@@ -1,5 +1,4 @@
 @forward '#scss/sharedClasses';
 @forward '#scss/type';
-@forward '#scss/typography';
 @forward '#scss/utils';
 @forward '#scss/vars';

--- a/src/scss/_type.scss
+++ b/src/scss/_type.scss
@@ -1,5 +1,38 @@
 @use './vars' as *;
 
+@mixin headerText {
+  @include DistinctDisplay;
+
+  color: $primary-black;
+  font-weight: 400;
+}
+
+@mixin bodyText {
+  color: $soft-black;
+}
+
+@mixin DistinctItalic {
+  font-family: Distinct, sans-serif;
+  font-style: italic;
+}
+
+@mixin DistinctDisplay {
+  font-family: DistinctDisplay, sans-serif;
+}
+
+@mixin DistinctDisplayItalic {
+  font-family: DistinctDisplay, sans-serif;
+  font-style: italic;
+}
+
+@mixin Montserrat {
+  font-family: Montserrat, sans-serif;
+}
+
+@mixin DistinctText {
+  font-family: Distinct, sans-serif;
+}
+
 @mixin underline($padding: 0, $width: 0.0625rem, $color: $cta-blue) {
   border-bottom: $width solid $color;
   padding-bottom: $padding;

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -32,20 +32,11 @@ body {
   src: url('../fonts/Distinct-Display.woff2') format('woff2');
 }
 
-@mixin DistinctDisplay {
-  font-family: DistinctDisplay, sans-serif;
-}
-
 @font-face {
   font-family: DistinctDisplay;
   font-style: italic;
   src: url('../fonts/Distinct-DisplayItalic.woff') format('woff');
   src: url('../fonts/Distinct-DisplayItalic.woff2') format('woff2');
-}
-
-@mixin DistinctDisplayItalic {
-  font-family: DistinctDisplay, sans-serif;
-  font-style: italic;
 }
 
 /** Fonts **/
@@ -55,18 +46,10 @@ body {
   src: url('../fonts/Montserrat.woff2') format('woff2');
 }
 
-@mixin Montserrat {
-  font-family: Montserrat, sans-serif;
-}
-
 @font-face {
   font-family: Distinct;
   src: url('../fonts/Distinct-Text.woff') format('woff');
   src: url('../fonts/Distinct-Text.woff2') format('woff2');
-}
-
-@mixin DistinctText {
-  font-family: Distinct, sans-serif;
 }
 
 @font-face {
@@ -74,20 +57,4 @@ body {
   font-style: italic;
   src: url('../fonts/Distinct-Italic.woff') format('woff');
   src: url('../fonts/Distinct-Italic.woff2') format('woff2');
-}
-
-@mixin DistinctItalic {
-  font-family: Distinct, sans-serif;
-  font-style: italic;
-}
-
-@mixin headerText {
-  @include DistinctDisplay;
-
-  color: $primary-black;
-  font-weight: 400;
-}
-
-@mixin bodyText {
-  color: $soft-black;
 }


### PR DESCRIPTION
**Jira ticket**

[Jira Ticket ID](https://phillipsauctions.atlassian.net/browse/L3-3127)

**Summary**

If a downstream consumer only imported the `componentStyles.scss` the fonts would not be loaded.  We want component styles to be fully functional without requiring consumers to import `allPartials.scss`

**Change List (describe the changes made to the files)**

- change(componentStyles): bring in the fonts
- change(allPartials): don't bring in the fonts here
- change(type): move the mixins here that were in typography so it's only fonts
- change(typography): move the mixins from this file to the type file

**Acceptance Test (how to verify the PR)**

- `npm run build`
- `npm link`

Go the remix project
`npm link @phillips/seldon`

Remove the seldon `allPartials` import from the `allPartials.scss` file
![image](https://github.com/user-attachments/assets/19c63ee1-0e9d-4ae1-83f5-e75e4784ab94)

Change `about.scss` to be this
```@use './vars' as *;

.#{$pah-px}-about-page {
  &--background {
    background-color: white;
  }
}
```

Now no one should be importing the seldon `allPartials` file any more.

 `npm run clean && npm run build && npm run start`

The fonts should still be loaded even without importing seldon's `allPartials.scss`.

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

![image](https://github.com/user-attachments/assets/a2e8ad7e-6ad4-4c9e-8506-423378d9f35a)

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
