### PR TITLE
fix(accordion): L3-3274 add "variant" prop to Accordion

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,10 +1,20 @@
 import { Meta } from '@storybook/react';
 import Accordion, { AccordionProps } from './Accordion';
 import AccordionItem from './AccordionItem';
+import { AccordionVariants } from './types';
 
 const meta = {
   title: 'Components/Accordion',
   component: Accordion,
+
+  argTypes: {
+    variant: {
+      options: Object.values(AccordionVariants),
+      control: {
+        type: 'select',
+      },
+    },
+  },
 } satisfies Meta<typeof Accordion>;
 
 export default meta;

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Accordion from './Accordion';
-import AccordionItem from './AccordionItem';
+import { Accordion, AccordionItem } from './';
 import { runCommonTests } from '../../utils/testUtils';
+import { getAccordionVariantProps } from './utils';
 
 describe('Accordion', () => {
   runCommonTests(Accordion, 'Accordion');
@@ -97,5 +97,33 @@ describe('Accordion', () => {
     await waitFor(() => {
       expect(container.getElementsByClassName('phillips-accordion-item--expanded').length).toBe(1);
     });
+  });
+
+  it('should get the correct variant props for the "singleCollapsible" variant', () => {
+    const variantProps = getAccordionVariantProps('singleCollapsible');
+
+    expect(variantProps.type).toBe('single');
+    expect(variantProps.collapsible).toBe(true);
+  });
+
+  it('should get the correct variant props for the "singleNonCollapsible" variant', () => {
+    const variantProps = getAccordionVariantProps('singleNonCollapsible');
+
+    expect(variantProps.type).toBe('single');
+    expect(variantProps.collapsible).toBe(false);
+  });
+
+  it('should get the correct variant props for the "multiple" variant', () => {
+    const variantProps = getAccordionVariantProps('multiple');
+
+    expect(variantProps.type).toBe('multiple');
+    expect(variantProps.collapsible).toBeUndefined();
+  });
+
+  it('should default to the variant props for "multiple" if no variant is passed in', () => {
+    const variantProps = getAccordionVariantProps();
+
+    expect(variantProps.type).toBe('multiple');
+    expect(variantProps.collapsible).toBeUndefined();
   });
 });

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,41 +1,10 @@
-import { AccordionVariantKey, AccordionVariants } from './types';
+import { AccordionVariantKey } from './types';
 
 import React from 'react';
 import classnames from 'classnames';
 import { getCommonProps } from '../../utils';
 import * as Accordion from '@radix-ui/react-accordion';
-
-interface AccordionVariantProps {
-  /**
-   * Determines whether multiple elements can be opened at the same time or not.
-   */
-  type: 'single' | 'multiple';
-  /**
-   * Determines if an open element can be closed by clicking on it.
-   * Only applicable to the `single` variants.
-   */
-  collapsible?: boolean;
-}
-
-/**
- * Sets the type and collapsible props based on the variant prop
- * The collapsible prop should only be passed when the variant is single
- */
-const getAccordionVariantProps = (variant?: AccordionVariantKey): AccordionVariantProps => {
-  const variantProps: AccordionVariantProps = { type: 'multiple' };
-
-  if (variant === AccordionVariants.singleCollapsible) {
-    variantProps.type = 'single';
-    variantProps.collapsible = true;
-  }
-
-  if (variant === AccordionVariants.singleNonCollapsible) {
-    variantProps.type = 'single';
-    variantProps.collapsible = false;
-  }
-
-  return variantProps;
-};
+import { getAccordionVariantProps } from './utils';
 
 export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
   /**

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,13 +1,54 @@
+import { AccordionVariantKey, AccordionVariants } from './types';
+
 import React from 'react';
 import classnames from 'classnames';
 import { getCommonProps } from '../../utils';
 import * as Accordion from '@radix-ui/react-accordion';
+
+interface AccordionVariantProps {
+  /**
+   * Determines whether multiple elements can be opened at the same time or not.
+   */
+  type: 'single' | 'multiple';
+  /**
+   * Determines if an open element can be closed by clicking on it.
+   * Only applicable to the `single` variants.
+   */
+  collapsible?: boolean;
+}
+
+/**
+ * Sets the type and collapsible props based on the variant prop
+ * The collapsible prop should only be passed when the variant is single
+ */
+const getAccordionVariantProps = (variant?: AccordionVariantKey): AccordionVariantProps => {
+  const variantProps: AccordionVariantProps = { type: 'multiple' };
+
+  if (variant === AccordionVariants.singleCollapsible) {
+    variantProps.type = 'single';
+    variantProps.collapsible = true;
+  }
+
+  if (variant === AccordionVariants.singleNonCollapsible) {
+    variantProps.type = 'single';
+    variantProps.collapsible = false;
+  }
+
+  return variantProps;
+};
 
 export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Unique id for component testing
    */
   id?: string;
+  /**
+   * Determines the Accordion variant to use. `multiple` allows multiple elements to be opened at the same time.
+   * The `single` variants only allow one element opened at a time.
+   * `singleCollapsible` allows users to close an open element by clicking on it, while `singleNonCollapsible` does not.
+   * Defaults to `multiple`.
+   */
+  variant?: AccordionVariantKey;
   /**
    * Child element pass in to display as item content.
    */
@@ -20,13 +61,19 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
  *
  * [Figma Link](https://www.figma.com/design/xMuOXOAKVt5HC7hgYjF3ot/Components-v2.0?node-id=4433-163013&t=lhB2YjBptvQ97UWF-0)
  *
- * [Storybook Link](Point back to yourself here)
+ * [Storybook Link](https://phillips-seldon.netlify.app/?path=/docs/components-accordion--overview)
  */
-const accordionType = 'multiple';
 const AccordionComponent = ({ className, children, ...props }: AccordionProps) => {
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'Accordion');
+  const variantProps = getAccordionVariantProps(props.variant);
+
   return (
-    <Accordion.Root className={classnames(`${baseClassName}`, className)} type={type} {...commonProps} id={props?.id}>
+    <Accordion.Root
+      className={classnames(`${baseClassName}`, className)}
+      {...commonProps}
+      {...variantProps}
+      id={props?.id}
+    >
       {children}
     </Accordion.Root>
   );

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import { getCommonProps } from '../../utils';
 import * as Accordion from '@radix-ui/react-accordion';
 
-// You'll need to change the HTMLDivElement to match the top-level element of your component
 export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Unique id for component testing
@@ -27,12 +26,7 @@ const accordionType = 'multiple';
 const AccordionComponent = ({ className, children, ...props }: AccordionProps) => {
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'Accordion');
   return (
-    <Accordion.Root
-      className={classnames(`${baseClassName}`, className)}
-      type={accordionType}
-      {...commonProps}
-      id={props?.id}
-    >
+    <Accordion.Root className={classnames(`${baseClassName}`, className)} type={type} {...commonProps} id={props?.id}>
       {children}
     </Accordion.Root>
   );

--- a/src/components/Accordion/types.ts
+++ b/src/components/Accordion/types.ts
@@ -65,3 +65,20 @@ export interface AccordionContentType {
    */
   isCollapsed: boolean;
 }
+
+export enum AccordionVariants {
+  /*
+   * Allows multiple elements to be opened at the same time.
+   */
+  multiple = 'multiple',
+  /*
+   * Only allows one element opened at a time and allows users to close an open element by clicking on it.
+   */
+  singleCollapsible = 'singleCollapsible',
+  /*
+   * Only allows one element opened at a time. Elements cannot be closed by clicking on them.
+   */
+  singleNonCollapsible = 'singleNonCollapsible',
+}
+
+export type AccordionVariantKey = keyof typeof AccordionVariants;

--- a/src/components/Accordion/utils.ts
+++ b/src/components/Accordion/utils.ts
@@ -1,0 +1,33 @@
+import { AccordionVariantKey, AccordionVariants } from './types';
+
+export interface AccordionVariantProps {
+  /**
+   * Determines whether multiple elements can be opened at the same time or not.
+   */
+  type: 'single' | 'multiple';
+  /**
+   * Determines if an open element can be closed by clicking on it.
+   * Only applicable to the `single` variants.
+   */
+  collapsible?: boolean;
+}
+
+/**
+ * Sets the type and collapsible props based on the variant prop
+ * The collapsible prop should only be passed when the variant is single
+ */
+export const getAccordionVariantProps = (variant?: AccordionVariantKey): AccordionVariantProps => {
+  const variantProps: AccordionVariantProps = { type: 'multiple' };
+
+  if (variant === AccordionVariants.singleCollapsible) {
+    variantProps.type = 'single';
+    variantProps.collapsible = true;
+  }
+
+  if (variant === AccordionVariants.singleNonCollapsible) {
+    variantProps.type = 'single';
+    variantProps.collapsible = false;
+  }
+
+  return variantProps;
+};

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -120,7 +120,7 @@ const leftComponent = (
       </div>
     </div>
 
-    <Accordion className={`${px}-footer-mobile`}>
+    <Accordion variant="multiple" className={`${px}-footer-mobile`}>
       <AccordionItem
         isLocked={false}
         variation=""


### PR DESCRIPTION
**Jira ticket**

[L3-3274](https://phillipsauctions.atlassian.net/browse/L3-3274)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![L3-3274 - before](https://github.com/user-attachments/assets/56a6c727-34af-436e-b7a9-02b1ea754b36) | ![L3-3274 - after](https://github.com/user-attachments/assets/fad1c3b8-72f8-44e3-9f11-dcee3590ecc6) |

**Summary**

Fixes the console error coming from the Accordion component. The error was a little misleading, it was complaining about the `collapsible` prop being passed to the DOM as a boolean instead of a string, but the error was actually caused by the fact that we didn't need to pass in the `collapsible` prop at all because the Accordion `type` was set to `multiple`. When the prop is `multiple`, the child components are already set to be collapsible, and I think that the `collapsible` prop we were passing in was being treated as an extra prop and getting passed all the way through, down to the `div` on the DOM. By removing the extra prop, the component still works the same and it eliminates that error. 

**Change List (describe the changes made to the files)**

- Accordion.tsx
  - Replaced `type` prop with `variant`
- Accordion/utils.ts
  - Added getAccordionVariantProps helper
- Accordion/types.ts 
  - Added AccordionVariants enum
- Accordion.test.tsx
  - Added tests and increased coverage
- Accordion.stories.tsx
  - Updated to pass in correct props to <Accordion />
- Footer.stories.tsx
  - Updated to pass in correct props to <Accordion />
  
**Acceptance Test (how to verify the PR)**
In seldon:
`npm run build`
`npm link`

In phillips-public-remix:
`npm link @phillips/seldon`
`npm run dev`

Navigate to `localhost:3000` and check the remix server for errors. Confirm the below error no longer occurs:
`Warning: Received 'true' for a non-boolean attribute 'collapsible'.`


**Regression Test**

- Follow the steps above and confirm that the Footer component on the page loads and functions properly

**Evidence of testing**

![L3-3274 - after](https://github.com/user-attachments/assets/fad1c3b8-72f8-44e3-9f11-dcee3590ecc6) 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-3274]: https://phillipsauctions.atlassian.net/browse/L3-3274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ