### PR TITLE
fix(accordion): L3-3439 accordion fixes

### DIFF
--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -91,12 +91,20 @@ describe('Accordion', () => {
         ))}
       </Accordion>,
     );
-    expect(screen.queryByTestId(/accordion-item-0-plusIcon/)).toBeInTheDocument();
-    expect(screen.queryByTestId(/accordion-item-1-lockedIcon/)).toBeInTheDocument();
+
+    // Should have 2 closed items
+    expect(container.querySelectorAll(`.phillips-accordion-item[data-state="open"]`)).toHaveLength(0);
+    expect(container.querySelectorAll(`.phillips-accordion-item[data-state="closed"]`)).toHaveLength(2);
+
+    // After clicking first item, we should have 1 open and 1 closed item
     await userEvent.click(screen.getByTestId('accordion-item-0-trigger'));
-    await waitFor(() => {
-      expect(container.getElementsByClassName('phillips-accordion-item--expanded').length).toBe(1);
-    });
+    expect(container.querySelectorAll(`.phillips-accordion-item[data-state="open"]`)).toHaveLength(1);
+    expect(container.querySelectorAll(`.phillips-accordion-item[data-state="closed"]`)).toHaveLength(1);
+
+    // After clicking second item, we should have both items open and none closed
+    await userEvent.click(screen.getByTestId('accordion-item-1-trigger'));
+    expect(container.querySelectorAll(`.phillips-accordion-item[data-state="open"]`)).toHaveLength(2);
+    expect(container.querySelectorAll(`.phillips-accordion-item[data-state="closed"]`)).toHaveLength(0);
   });
 
   it('should get the correct variant props for the "singleCollapsible" variant', () => {

--- a/src/components/Accordion/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { getCommonProps, noOp } from '../../utils';
+import React from 'react';
+import { getCommonProps } from '../../utils';
 import plusIcon from '../../assets/plus.svg';
 import minusIcon from '../../assets/minus.svg';
 import lockIcon from '../../assets/lock.svg';
 import classnames from 'classnames';
 import * as Accordion from '@radix-ui/react-accordion';
 import { AccordionHeaderType, AccordionContentType } from './types';
+import { getIconClasses } from './utils';
 
 export interface AccordionItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -32,10 +33,6 @@ export interface AccordionItemProps extends React.HTMLAttributes<HTMLDivElement>
    * When true applied the transition keyframe animation on item expand. Default as false.
    */
   hasTransition?: boolean;
-  /**
-   * When true, isCollapsed won't be toggled.
-   */
-  isControlled?: boolean;
 }
 /**
  * ## Overview
@@ -48,30 +45,52 @@ const AccordionHeader = ({
   className,
   baseClassName,
   disable,
-  isCollapsed,
-  setIsCollapsed,
   isLargeVariation,
   id,
 }: AccordionHeaderType) => {
-  const handleClick = () => !disable && setIsCollapsed((prevState) => !prevState);
-  const icon = disable ? lockIcon : isCollapsed ? plusIcon : minusIcon;
-  const dataTestId = `${id}-` + (disable ? 'lockedIcon' : isCollapsed ? 'plusIcon' : 'minusIcon');
+  const showLock = disable;
+
+  // Render all icons and use css to conditionally show/hide the correct one
+  const lockIconComponent = (
+    <img
+      className={getIconClasses(baseClassName, isLargeVariation, 'lock')}
+      src={lockIcon}
+      data-testid={`${id}-lockedIcon`}
+      aria-hidden
+    />
+  );
+
+  const plusIconComponent = (
+    <img
+      className={getIconClasses(baseClassName, isLargeVariation, 'plus')}
+      src={plusIcon}
+      data-testid={`${id}-plusIcon`}
+      aria-hidden
+    />
+  );
+
+  const minusIconComponent = (
+    <img
+      className={getIconClasses(baseClassName, isLargeVariation, 'minus')}
+      src={minusIcon}
+      data-testid={`${id}-minusIcon`}
+      aria-hidden
+    />
+  );
+
   return (
     <Accordion.Trigger
       data-disabled={disable}
       asChild
       className={classnames(baseClassName, { [`${baseClassName}--hoverable`]: !disable }, className)}
     >
-      <div onClick={handleClick} data-testid={`${id}-trigger`}>
+      <div data-testid={`${id}-trigger`}>
         <div className={classnames(`${baseClassName}__text`, { [`${baseClassName}__text--lg`]: isLargeVariation })}>
           {children}
         </div>
-        <img
-          className={classnames(`${baseClassName}__icon`, { [`${baseClassName}__icon--lg`]: isLargeVariation })}
-          src={icon}
-          data-testid={dataTestId}
-          aria-hidden
-        />
+        {showLock && lockIconComponent}
+        {!showLock && plusIconComponent}
+        {!showLock && minusIconComponent}
       </div>
     </Accordion.Trigger>
   );
@@ -83,7 +102,6 @@ const AccordionContent = ({
   disable,
   hasTransition,
   isLargeVariation,
-  isCollapsed,
   className,
 }: AccordionContentType) => (
   <>
@@ -95,7 +113,6 @@ const AccordionContent = ({
         className={classnames(
           { [`${baseClassName}__content--lg`]: isLargeVariation },
           { [`${baseClassName}--transition`]: hasTransition },
-          { [`${baseClassName}--expanded`]: !isCollapsed },
           className,
         )}
       >
@@ -112,10 +129,8 @@ const AccordionItem = ({
   isLastItem,
   hasTransition = false,
   children,
-  isControlled = true,
   ...props
 }: AccordionItemProps) => {
-  const [isCollapsed, setIsCollapsed] = useState(true);
   const { className: baseClassName } = getCommonProps(props, 'Accordion');
   const isLargeVariation = variation === 'lg';
   const accordionItemClassName = `${baseClassName}-item`;
@@ -129,8 +144,6 @@ const AccordionItem = ({
       <AccordionHeader
         disable={isLocked}
         isLargeVariation={isLargeVariation}
-        isCollapsed={isCollapsed}
-        setIsCollapsed={isControlled ? setIsCollapsed : noOp}
         id={props?.id}
         baseClassName={`${accordionItemClassName}-label`}
       >
@@ -141,7 +154,6 @@ const AccordionItem = ({
         disable={isLocked}
         hasTransition={hasTransition}
         isLargeVariation={isLargeVariation}
-        isCollapsed={isCollapsed}
         baseClassName={accordionItemClassName}
       >
         {children}

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -14,7 +14,7 @@
     border-bottom: 1px solid $keyline-gray;
   }
 
-  &--expanded {
+  &[data-state='open'] {
     display: block;
     font-weight: 400;
     height: auto;
@@ -37,6 +37,26 @@
 
   &--transition[data-state='closed'] {
     animation: slide-up 250ms end;
+  }
+
+  &[data-state='open'] {
+    .phillips-accordion-item-label-plus__icon {
+      display: none;
+    }
+
+    .phillips-accordion-item-label-minus__icon {
+      display: block;
+    }
+  }
+
+  &[data-state='closed'] {
+    .phillips-accordion-item-label-plus__icon {
+      display: block;
+    }
+
+    .phillips-accordion-item-label-minus__icon {
+      display: none;
+    }
   }
 
   @keyframes slide-down {

--- a/src/components/Accordion/types.ts
+++ b/src/components/Accordion/types.ts
@@ -17,14 +17,6 @@ export interface AccordionHeaderType {
    */
   disable: boolean;
   /*
-   * When true, shows the locked icon.
-   */
-  isCollapsed: boolean;
-  /*
-   * When called it toggles the icon svg displayed.
-   */
-  setIsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
-  /*
    * When true, shows the large variation text style.
    */
   isLargeVariation: boolean;
@@ -60,10 +52,6 @@ export interface AccordionContentType {
    * When true, shows the large variation text style.
    */
   isLargeVariation: boolean;
-  /*
-   * When true, and not disabled, hide the children passed in.
-   */
-  isCollapsed: boolean;
 }
 
 export enum AccordionVariants {

--- a/src/components/Accordion/utils.ts
+++ b/src/components/Accordion/utils.ts
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { AccordionVariantKey, AccordionVariants } from './types';
 
 export interface AccordionVariantProps {
@@ -31,3 +32,15 @@ export const getAccordionVariantProps = (variant?: AccordionVariantKey): Accordi
 
   return variantProps;
 };
+
+/**
+ * A helper for getting the classes of the Accordion icons
+ * @param className - The className of the component
+ * @param isLargeVariation - Determines whether the variation on text style is large or small.
+ * @param iconName - The name of the icon to be displayed
+ * @returns the classes that should be applied for the icon
+ */
+export const getIconClasses = (className: string, isLargeVariation: boolean, iconName: string) =>
+  classnames(`${className}__icon`, `${className}-${iconName}__icon`, {
+    [`${className}__icon--lg`]: isLargeVariation,
+  });


### PR DESCRIPTION
**Jira ticket**

[L3-3439](https://phillipsauctions.atlassian.net/browse/L3-3439)

**Screenshots**
| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/49ae04b5-010a-4ca5-bfab-c3458085baca | https://github.com/user-attachments/assets/dd5fa1eb-d45f-4f57-b334-f535fa9d00ee |

**Summary**

I updated the Accordion component to fix the behavior of the icons when sections are expanded and collapsed. Previously, they were relying on custom logic to determine the "collapsed" state of each panel, but there is an attribute that radix already uses to determine the collpased state, `data-state="open"` and `data-state="closed"`. I just rendered the icons in the component and use css and the `datta-state` to determine which one to hide and which one to show.

**Change List (describe the changes made to the files)**

* src/components/Accordion/Accordion.test.tsx
  * Updated tests
* src/components/Accordion/AccordionItem.tsx
  * Updated logic used to show open/close icons
* src/components/Accordion/_accordion.scss
  * Updated css to support new logic
* src/components/Accordion/types.ts
  * Removing typing of extra props that are no longer needed
* src/components/Accordion/utils.ts
  * Added a helper: `getIconClasses` to DRY up AccordionItem


**Acceptance Test (how to verify the PR)**

Verify that any uses of the @seldon Accordion component that are using a `single*` variant have panels that open and close properly and the icons on those panels update accordingly based on whether the panel is open or closed.

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

See attached video

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-3439]: https://phillipsauctions.atlassian.net/browse/L3-3439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ