### PR TITLE
fix(build): L3-3777 build process not handling new patterns and site-furniture

### DIFF
--- a/src/build/buildUtils.ts
+++ b/src/build/buildUtils.ts
@@ -2,12 +2,12 @@ import path from 'path';
 import glob from 'glob';
 
 export const transformScssAlias = (contents: Buffer, name: string) => {
-  const filePath = glob.sync(`**/${name}`, { cwd: path.resolve(__dirname, '../../src/components') })[0];
+  const filePath = glob.sync(`**/${name}`, { cwd: path.resolve(__dirname, '../../src') })[0];
+  console.log('transforming scss alias for file:', filePath);
   if (!filePath) {
     return contents;
   }
-  // console.log('updating scss alias for file:', name);
-  const countOfSubDirectories = filePath.split('/').length;
+  const countOfSubDirectories = filePath.split('/').length - 1;
 
   return contents.toString().replace(
     /#scss/g,

--- a/src/componentStyles.scss
+++ b/src/componentStyles.scss
@@ -32,11 +32,11 @@
 @use 'components/HTMLParser/htmlParser';
 @use 'components/Dropdown/dropdown';
 @use 'components/Video/video';
+@use 'components/ContentPeek/contentPeek';
 
 // Patterns
 @use 'patterns/HeroBanner/heroBanner';
 @use 'patterns/LanguageSelector/languageSelector';
-@use 'patterns/ReadMore/readMore';
 @use 'patterns/UserManagement/userManagement';
 @use 'patterns/ViewingsList/viewingsList';
 @use 'patterns/Subscribe/subscribe';

--- a/src/components/ContentPeek/ContentPeek.stories.tsx
+++ b/src/components/ContentPeek/ContentPeek.stories.tsx
@@ -1,15 +1,15 @@
 import { Meta } from '@storybook/react';
-import ReadMore, { ReadMoreProps } from './ReadMore';
+import ContentPeek, { ContentPeekProps } from './ContentPeek';
 
 const meta = {
-  title: 'Patterns/ReadMore',
-  component: ReadMore,
+  title: 'Components/ContentPeek',
+  component: ContentPeek,
   argTypes: {
-    readMoreText: { control: 'text' },
-    readLessText: { control: 'text' },
+    contentExpandText: { control: 'text' },
+    contentCollapseText: { control: 'text' },
     maxHeight: { control: 'number' },
   },
-} satisfies Meta<typeof ReadMore>;
+} satisfies Meta<typeof ContentPeek>;
 
 export default meta;
 
@@ -24,26 +24,26 @@ const sampleText = `
   Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 `;
 
-export const Playground = (args: ReadMoreProps) => (
+export const Playground = (args: ContentPeekProps) => (
   <>
-    <ReadMore {...args}>{sampleText}</ReadMore>
+    <ContentPeek {...args}>{sampleText}</ContentPeek>
   </>
 );
 
 Playground.args = {
-  readMoreText: 'Read More',
-  readLessText: 'Read Less',
+  contentExpandText: 'Read More',
+  contentCollapseText: 'Read Less',
   maxHeight: 150,
 };
 
-export const CustomText = (args: ReadMoreProps) => (
-  <ReadMore {...args}>
+export const CustomText = (args: ContentPeekProps) => (
+  <ContentPeek {...args}>
     <p>{sampleText}</p>
-  </ReadMore>
+  </ContentPeek>
 );
 
 CustomText.args = {
-  readMoreText: 'Show More',
-  readLessText: 'Show Less',
+  contentExpandText: 'Show More',
+  contentCollapseText: 'Show Less',
   maxHeight: 150,
 };

--- a/src/components/ContentPeek/ContentPeek.test.tsx
+++ b/src/components/ContentPeek/ContentPeek.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import ReadMore from './ReadMore';
+import ContentPeek from './ContentPeek';
 import { runCommonTests } from '../../utils/testUtils';
 import { px } from '../../utils';
 
-describe('ReadMore', () => {
-  runCommonTests(ReadMore, 'ReadMore');
+describe('ContentPeek', () => {
+  runCommonTests(ContentPeek, 'ContentPeek');
 
   // Mock scrollHeight property
   // https://github.com/testing-library/react-testing-library/issues/353#issuecomment-510046921
@@ -29,13 +29,13 @@ describe('ReadMore', () => {
 
   it('should render the component with default props (short content)', () => {
     setShortScrollHeight();
-    render(<ReadMore>Test content</ReadMore>);
+    render(<ContentPeek>Test content</ContentPeek>);
     expect(screen.getByText('Test content')).toBeInTheDocument();
   });
 
   it('should render the component with default props (long content)', async () => {
     setTallScrollHeight();
-    render(<ReadMore maxHeight={50}>{'Test content'.repeat(100)}</ReadMore>);
+    render(<ContentPeek maxHeight={50}>{'Test content'.repeat(100)}</ContentPeek>);
     expect(screen.getByText('Test content'.repeat(100))).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByText('Read More')).toBeInTheDocument();
@@ -45,36 +45,36 @@ describe('ReadMore', () => {
   it('should expand and collapse content on button click and toggle gradient visibility', async () => {
     setTallScrollHeight();
     const longContent = 'Lorem ipsum '.repeat(100);
-    const { container } = render(<ReadMore maxHeight={50}>{longContent}</ReadMore>);
+    const { container } = render(<ContentPeek maxHeight={50}>{longContent}</ContentPeek>);
     await waitFor(() => {
       expect(screen.getByRole('button')).toBeInTheDocument();
     });
 
     const button = screen.getByRole('button');
-    const overlayElement = container.querySelector(`.${px}-read-more-overlay`);
+    const overlayElement = container.querySelector(`.${px}-content-peek-overlay`);
 
     expect(button).toHaveTextContent('Read More');
-    expect(overlayElement).toHaveClass(`${px}-read-more-overlay--gradient`);
+    expect(overlayElement).toHaveClass(`${px}-content-peek-overlay--gradient`);
     expect(overlayElement).toBeVisible();
 
     await userEvent.click(button);
     await waitFor(() => {
       expect(button).toHaveTextContent('Read Less');
-      expect(overlayElement).not.toHaveClass(`${px}-read-more-overlay--gradient`);
+      expect(overlayElement).not.toHaveClass(`${px}-content-peek-overlay--gradient`);
     });
 
     await userEvent.click(button);
     await waitFor(() => {
       expect(button).toHaveTextContent('Read More');
-      expect(overlayElement).toHaveClass(`${px}-read-more-overlay--gradient`);
+      expect(overlayElement).toHaveClass(`${px}-content-peek-overlay--gradient`);
     });
   });
   it('should use custom read more and read less text', async () => {
     setTallScrollHeight();
     render(
-      <ReadMore readMoreText="Show More" readLessText="Show Less" maxHeight={50}>
+      <ContentPeek contentExpandText="Show More" contentCollapseText="Show Less" maxHeight={50}>
         Test content.repeat(100)
-      </ReadMore>,
+      </ContentPeek>,
     );
     await waitFor(() => {
       expect(screen.getByText('Show More')).toBeInTheDocument();
@@ -83,7 +83,7 @@ describe('ReadMore', () => {
 
   it('should not show read more button when content is shorter than maxHeight', async () => {
     setShortScrollHeight();
-    render(<ReadMore maxHeight={1000}>Short content</ReadMore>);
+    render(<ContentPeek maxHeight={1000}>Short content</ContentPeek>);
     await waitFor(() => {
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
     });
@@ -91,17 +91,17 @@ describe('ReadMore', () => {
 
   it('should apply correct classes based on expanded state', async () => {
     setTallScrollHeight();
-    const { container } = render(<ReadMore maxHeight={50}>{'Lorem ipsum '.repeat(100)}</ReadMore>);
+    const { container } = render(<ContentPeek maxHeight={50}>{'Lorem ipsum '.repeat(100)}</ContentPeek>);
 
     const readMoreElement = container.firstChild as HTMLElement;
-    expect(readMoreElement).toHaveClass(`${px}-read-more`);
+    expect(readMoreElement).toHaveClass(`${px}-content-peek`);
 
-    const overlayElement = container.querySelector(`.${px}-read-more-overlay`);
-    expect(overlayElement).toHaveClass(`${px}-read-more-overlay--gradient`);
+    const overlayElement = container.querySelector(`.${px}-content-peek-overlay`);
+    expect(overlayElement).toHaveClass(`${px}-content-peek-overlay--gradient`);
 
     await userEvent.click(screen.getByRole('button'));
     await waitFor(() => {
-      expect(overlayElement).not.toHaveClass(`${px}-read-more-overlay--gradient`);
+      expect(overlayElement).not.toHaveClass(`${px}-content-peek-overlay--gradient`);
     });
   });
 });

--- a/src/components/ContentPeek/ContentPeek.tsx
+++ b/src/components/ContentPeek/ContentPeek.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useRef, useEffect, forwardRef, useCallback } from 'react';
 import classnames from 'classnames';
 import { getCommonProps } from '../../utils';
-import Button from '../../components/Button/Button';
-import { ButtonVariants } from '../../components/Button/types';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../components/Collapsible';
+import Button from '../Button/Button';
+import { ButtonVariants } from '../Button/types';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../Collapsible';
 import PlusIcon from '../../assets/plus.svg?react';
 import MinusIcon from '../../assets/minus.svg?react';
 
-export interface ReadMoreProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ContentPeekProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Unique id for component testing
    */
@@ -17,13 +17,13 @@ export interface ReadMoreProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   children?: React.ReactNode;
   /**
-   * Text for the "Read More" button
+   * Text for the "Content Expand" button
    */
-  readMoreText?: string;
+  contentExpandText?: string;
   /**
-   * Text for the "Read Less" button
+   * Text for the "Content Collapse" button
    */
-  readLessText?: string;
+  contentCollapseText?: string;
   /**
    * Maximum height of the content when collapsed
    */
@@ -33,16 +33,26 @@ export interface ReadMoreProps extends React.HTMLAttributes<HTMLDivElement> {
 /**
  * ## Overview
  *
- * A component for displaying expandable content with a "Read More" functionality.
+ * A component for displaying expandable content with a "ContentPeek" functionality allowing you to see the first part of the content and expand to see more.
  *
  * This component is a wrapper around the Collapsible and Button component and uses the CollapsibleTrigger and CollapsibleContent components to control the expand and collapse functionality.
  *
  * [Figma Link](https://www.figma.com/design/hMu9IWH5N3KamJy8tLFdyV/EASEL-Compendium%3A-Tokens%2C-Components-%26-Patterns?node-id=7755-5572&t=JCYbkM8yQcdb51UQ-4)
  *
  */
-const ReadMore = forwardRef<HTMLDivElement, ReadMoreProps>(
-  ({ className, children, readMoreText = 'Read More', readLessText = 'Read Less', maxHeight = 480, ...props }, ref) => {
-    const { className: baseClassName, ...commonProps } = getCommonProps(props, 'ReadMore');
+const ContentPeek = forwardRef<HTMLDivElement, ContentPeekProps>(
+  (
+    {
+      className,
+      children,
+      contentExpandText = 'Read More',
+      contentCollapseText = 'Read Less',
+      maxHeight = 480,
+      ...props
+    },
+    ref,
+  ) => {
+    const { className: baseClassName, ...commonProps } = getCommonProps(props, 'ContentPeek');
     const [isExpanded, setIsExpanded] = useState(false);
     const [hasOverflow, setHasOverflow] = useState(false);
     const contentRef = useRef<HTMLDivElement>(null);
@@ -65,7 +75,7 @@ const ReadMore = forwardRef<HTMLDivElement, ReadMoreProps>(
         className={classnames(baseClassName, className)}
         style={
           {
-            '--read-more-max-height': `${maxHeight}px`,
+            '--content-peek-max-height': `${maxHeight}px`,
           } as React.CSSProperties
         }
         ref={ref}
@@ -86,7 +96,7 @@ const ReadMore = forwardRef<HTMLDivElement, ReadMoreProps>(
               <CollapsibleTrigger asChild className={`${baseClassName}-overlay-trigger`}>
                 <Button variant={ButtonVariants.secondary}>
                   {isExpanded ? <MinusIcon /> : <PlusIcon />}
-                  {isExpanded ? readLessText : readMoreText}
+                  {isExpanded ? contentCollapseText : contentExpandText}
                 </Button>
               </CollapsibleTrigger>
             </div>
@@ -97,6 +107,6 @@ const ReadMore = forwardRef<HTMLDivElement, ReadMoreProps>(
   },
 );
 
-ReadMore.displayName = 'ReadMore';
+ContentPeek.displayName = 'ContentPeek';
 
-export default ReadMore;
+export default ContentPeek;

--- a/src/components/ContentPeek/_contentPeek.scss
+++ b/src/components/ContentPeek/_contentPeek.scss
@@ -1,6 +1,6 @@
 @use '#scss/allPartials' as *;
 
-.#{$px}-read-more {
+.#{$px}-content-peek {
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -10,7 +10,7 @@
     overflow: hidden;
 
     &[data-state='closed'] {
-      max-height: var(--read-more-max-height);
+      max-height: var(--content-peek-max-height);
     }
   }
 

--- a/src/components/ContentPeek/index.ts
+++ b/src/components/ContentPeek/index.ts
@@ -1,0 +1,1 @@
+export { default as ContentPeek, type ContentPeekProps } from './ContentPeek';

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,6 @@ export { Breadcrumb, type BreadcrumbProps } from './components/Breadcrumb';
 export * from './components/Dropdown';
 export { default as Video, type VideoProps } from './components/Video/Video';
 export * from './patterns/LanguageSelector';
-export * from './patterns/ReadMore';
+export * from './components/ContentPeek';
 export * from './components/Collapsible';
 export * from './providers/SeldonProvider';

--- a/src/patterns/ReadMore/index.ts
+++ b/src/patterns/ReadMore/index.ts
@@ -1,1 +1,0 @@
-export { default as ReadMore, type ReadMoreProps } from './ReadMore';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,8 @@ import * as packageJson from './package.json';
 
 const plugins = [svgr(), react(), tsconfigPaths(), dts({ entryRoot: 'src' })];
 
+const scssFilesToTransform = ['src/**/*.scss', '!src/scss/**/*.scss', '!src/design/**', '!src/*.scss'];
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: plugins,
@@ -64,7 +66,7 @@ export default defineConfig({
           targets: [
             // Sass components
             {
-              src: ['src/components/**/*.scss', 'src/pages/**/*.scss'],
+              src: scssFilesToTransform,
               dest: ['dist/scss'],
               transform: transformScssAlias,
             },
@@ -82,8 +84,14 @@ export default defineConfig({
     setupFiles: ['./config/vitest/setupTest.ts'],
     restoreMocks: true,
     coverage: {
-      include: ['src/components/**/*.{ts,tsx}', 'src/utils/**/*.{ts,tsx}'],
-      exclude: ['**/*.test.{ts,tsx}', '**/*.stories.{ts,tsx}', '.template/**/*.{ts,tsx}', '**/index.ts'], // ignore barrel files
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        '**/*.test.{ts,tsx}',
+        '**/*.stories.{ts,tsx}',
+        '**/design/**/*.{ts,tsx}',
+        '.template/**/*.{ts,tsx}',
+        '**/index.ts',
+      ], // ignore barrel files
       reporter: ['text', 'json', 'html'],
       provider: 'v8',
       thresholds: {


### PR DESCRIPTION
**Jira ticket**

[Jira Ticket ID](https://phillipsauctions.atlassian.net/browse/L3-3777)

**Summary**

When I reorganized the component into `components` `patterns` and `site-furniture` our build process didn't transform all those new files correctly and led to consumer build failures. This change makes the transform process locate scss files in ANY new subdirectory. After the initial reorganization I got feedback from design that the "ReadMore" component should instead be called "ContentPeek" and a "component" rather than a "pattern"

**Change List (describe the changes made to the files)**

- change(buildUtils): better logging and support all directories not just `/src/components`
- change(componentStyles): flip `patterns/ReadMore` to `components/ContentPeek`
- change(ReadMore): change `ReadMore` to `ContentPeek` (and properties accordingly)
- change(vite.config.ts): fix the files to transform to an "exclude" glob rather than an "include" glob so that new subdirectories work correctly.  Fix testcase coverage that was missing the new `patterns` and `site-furniture` subdirectories

**Acceptance Test (how to verify the PR)**

- Verify that the ContentPeek component is in the right place in storybook
- Run `npm run build` and then link this project into Remix and run `npm run clean && npm run dev`

**Regression Test**

- Verify that the transformed `/dist/scss/components/**.scss` files of the `allPartials` import matches the correct path to the allPartials file in the `/dist` directory.  (i.e. `@use '../../allPartials' as *;` or `@use '../../../allPartials' as *;` depending on the level of component nesting.


**Evidence of testing**

- `npm run build`
Notice that only the components, patterns, pages, and site-furniture are transformed.
```
transforming scss alias for file: pages/_page.scss
transforming scss alias for file: components/Breadcrumb/_breadcrumb.scss
transforming scss alias for file: components/Accordion/_accordion.scss
transforming scss alias for file: components/ContentPeek/_contentPeek.scss
transforming scss alias for file: components/DatePicker/_datePicker.scss
transforming scss alias for file: components/Drawer/_drawer.scss
transforming scss alias for file: components/Dropdown/_dropdown.scss
transforming scss alias for file: components/Grid/_grid.scss
transforming scss alias for file: components/Button/_button.scss
transforming scss alias for file: components/IconButton/_iconButton.scss
transforming scss alias for file: components/GridItem/_gridItem.scss
transforming scss alias for file: components/Link/_link.scss
transforming scss alias for file: components/LinkBlock/_linkBlock.scss
transforming scss alias for file: components/Input/_input.scss
transforming scss alias for file: components/LinkList/_linkList.scss
transforming scss alias for file: components/Modal/_modal.scss
transforming scss alias for file: components/Modal/_modal.stories.scss
transforming scss alias for file: components/HTMLParser/_htmlParser.scss
transforming scss alias for file: components/Navigation/_navigation.scss
transforming scss alias for file: components/Search/_search.scss
transforming scss alias for file: components/Search/_searchButton.scss
transforming scss alias for file: components/Row/_row.scss
transforming scss alias for file: components/SplitPanel/_splitPanel.scss
transforming scss alias for file: components/SplitPanel/_splitPanel.stories.scss
transforming scss alias for file: components/Text/_text.scss
transforming scss alias for file: components/Toggle/_toggle.scss
transforming scss alias for file: patterns/Social/_social.scss
transforming scss alias for file: patterns/HeroBanner/_heroBanner.scss
transforming scss alias for file: components/Video/_video.scss
transforming scss alias for file: patterns/LanguageSelector/_languageSelector.scss
transforming scss alias for file: patterns/Subscribe/_subscribe.scss
transforming scss alias for file: patterns/ViewingsList/_viewingsList.scss
transforming scss alias for file: site-furniture/Header/_header.scss
transforming scss alias for file: patterns/UserManagement/_userManagement.scss
transforming scss alias for file: components/Navigation/NavigationItem/_navigationItem.scss
transforming scss alias for file: site-furniture/Footer/_footer.scss
transforming scss alias for file: components/Search/SearchResults/_searchResults.scss
transforming scss alias for file: components/Navigation/NavigationItemTrigger/_navigationItemTrigger.scss
transforming scss alias for file: components/Navigation/NavigationList/_navigationList.scss
```

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
