### PR TITLE
fix(boldedFonts): L3-3693 variable font weight not working in Safari

### DIFF
--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -21,7 +21,7 @@
 
   &[data-state='open'] {
     display: block;
-    font-weight: 400;
+    font-variation-settings: 'wght' 400;
     height: auto;
   }
 

--- a/src/components/Breadcrumb/_breadcrumb.scss
+++ b/src/components/Breadcrumb/_breadcrumb.scss
@@ -32,6 +32,6 @@
 
   &--current {
     color: $primary-black;
-    font-weight: 700;
+    font-variation-settings: 'wght' 700;
   }
 }

--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -10,7 +10,7 @@
   color: $pure-white;
   cursor: pointer;
   display: inline-flex;
-  font-weight: 600;
+  font-variation-settings: 'wght' 600;
   gap: $margin-xsm;
   justify-content: center;
   padding: 0 $padding-md;

--- a/src/components/DatePicker/_datePicker.scss
+++ b/src/components/DatePicker/_datePicker.scss
@@ -26,7 +26,7 @@
 
   .flatpickr-day.today {
     border-color: transparent;
-    font-weight: bold;
+    font-variation-settings: 'wght' 700;
     position: relative;
 
     @include DistinctDisplay;
@@ -64,7 +64,7 @@
   .flatpickr-weekday {
     @include DistinctDisplay;
 
-    font-weight: bold;
+    font-variation-settings: 'wght' 700;
   }
 
   .flatpickr-current-month {

--- a/src/components/Input/_input.scss
+++ b/src/components/Input/_input.scss
@@ -16,7 +16,7 @@ $lg: #{$px}-input--lg;
   &__label {
     color: $pure-black;
     font-size: 0.75rem;
-    font-weight: 600;
+    font-variation-settings: 'wght' 600;
     margin-bottom: 0.5rem;
     word-break: break-word;
 

--- a/src/components/Navigation/NavigationItem/_navigationItem.scss
+++ b/src/components/Navigation/NavigationItem/_navigationItem.scss
@@ -20,7 +20,7 @@
       content: '\203A';
       display: inline-block;
       font-size: 1.75rem;
-      font-weight: normal;
+      font-variation-settings: 'wght' 400;
       position: absolute;
       right: 0;
       top: 35%;

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -14,7 +14,7 @@
 
       appearance: none;
       border: none;
-      font-weight: 600;
+      font-variation-settings: 'wght' 600;
       line-height: 2.5rem;
       margin-bottom: 0;
       outline: none;

--- a/src/components/Search/_search.scss
+++ b/src/components/Search/_search.scss
@@ -84,7 +84,7 @@
         // Tokenize later
         font-size: 0.875rem;
         font-style: normal;
-        font-weight: 400;
+        font-variation-settings: 'wght' 400;
         height: $search-size;
         line-height: 1.5rem;
         margin: 0;

--- a/src/components/SplitPanel/_splitPanel.stories.scss
+++ b/src/components/SplitPanel/_splitPanel.stories.scss
@@ -7,7 +7,7 @@
     font-family: Montserrat, serif;
     font-size: 0.75rem;
     font-style: normal;
-    font-weight: 400;
+    font-variation-settings: 'wght' 400;
     letter-spacing: 0.0625rem;
     line-height: 1.125rem; /* 150% */
   }

--- a/src/design/Welcome.mdx
+++ b/src/design/Welcome.mdx
@@ -14,7 +14,7 @@ import StackAlt from './assets/stackalt.svg';
   {`
     .subheading {
       --mediumdark: '#999999';
-      font-weight: 700;
+      font-variation-settings: 'wght' 700;
       font-size: 13px;
       color: #999;
       letter-spacing: 6px;

--- a/src/design/colors-tokens/_color-card.scss
+++ b/src/design/colors-tokens/_color-card.scss
@@ -28,7 +28,7 @@
     &__token.#{$px}-color-card__token {
       color: $primary-black;
       font-size: 1.25rem;
-      font-weight: 700;
+      font-variation-settings: 'wght' 700;
       line-height: 1.5;
     }
 
@@ -47,14 +47,14 @@
 
     &__usage span {
       display: block;
-      font-weight: 700;
+      font-variation-settings: 'wght' 700;
       line-height: 1.625;
     }
 
     &__copied {
       animation: show-and-hide 2s ease-in-out;
       color: $pure-white;
-      font-weight: bold;
+      font-variation-settings: 'wght' 700;
       left: 50%;
       opacity: 0;
       position: absolute;
@@ -91,14 +91,14 @@
 
   &__usage span {
     display: block;
-    font-weight: 700;
+    font-variation-settings: 'wght' 700;
     line-height: 1.625;
   }
 
   &__copied {
     animation: show-and-hide 2s ease-in-out;
     color: $pure-white;
-    font-weight: bold;
+    font-variation-settings: 'wght' 700;
     left: 50%;
     opacity: 0;
     position: absolute;

--- a/src/design/type-tokens/_text-showcase.scss
+++ b/src/design/type-tokens/_text-showcase.scss
@@ -11,14 +11,14 @@
 
   .property {
     // @include pText($body-size2);
-    // font-weight: 400;
+    // font-variation-settings: 'wght' 400;
     color: $post-sale-magenta;
   }
 
   li:not(li strong) {
     color: $clock-widget-green;
     font-family: monospace;
-    font-weight: 600;
+    font-variation-settings: 'wght' 600;
   }
 
   li strong {
@@ -34,14 +34,14 @@
 
     .property {
       // @include pText($body-size2);
-      // font-weight: 400;
+      // font-variation-settings: 'wght' 400;
       color: $post-sale-magenta;
     }
 
     .h4 + ul li:not(li strong) {
       color: $clock-widget-green;
       font-family: monospace;
-      font-weight: 600;
+      font-variation-settings: 'wght' 600;
     }
 
     .h4 + ul li strong {

--- a/src/design/type-tokens/type-tokens.mdx
+++ b/src/design/type-tokens/type-tokens.mdx
@@ -429,16 +429,6 @@ line-height:</span> 1.5rem; <span className="property">font-weight:</span> 400 o
 - **BP1**: <span className="property">font-size:</span> 1rem;
 - **BP4**: <span className="property">font-size:</span> 1.56rem;
 
-<details>
-  <summary>Example</summary>
-
-```scss
-@include text($cta-lg);
-```
-
-  <span className="example example--cta-lg">example</span>
-</details>
-
 <h4 className="h4">
   Email: <span className="token">`$email`</span>
 </h4>
@@ -475,25 +465,6 @@ line-height:</span> 1.5rem; <span className="property">font-weight:</span> 400 o
 ```
 
   <span className="example example--label">example</span>
-</details>
-
-<h4 className="h4">
-  Badge: <span className="token">`$badge`</span>
-</h4>
-
-- **Default**: <span className="property">font-size:</span> 0.75rem; <span className="property">
-  line-height:</span> 1.25; <span className="property">letter-spacing:</span> 3px; <span className="property">font-weight:</span> 500; <span className="property">text-transform:</span> uppercase;
-- **BP1**: <span className="property">font-size:</span> 0.56rem;
-- **BP4**: <span className="property">font-size:</span> 1rem;
-
-<details>
-  <summary>Example</summary>
-
-```scss
-@include text($badge);
-```
-
-  <span className="example example--badge">example</span>
 </details>
 
 ## <span className="h3">Snowflake</span>

--- a/src/pages/_page.scss
+++ b/src/pages/_page.scss
@@ -11,7 +11,7 @@
 .storybook-page h2 {
   display: inline-block;
   font-size: 32px;
-  font-weight: 700;
+  font-variation-settings: 'wght' 700;
   line-height: 1;
   margin: 0 0 4px;
   vertical-align: top;
@@ -41,7 +41,7 @@
   color: #66bf3c;
   display: inline-block;
   font-size: 11px;
-  font-weight: 700;
+  font-variation-settings: 'wght' 700;
   line-height: 12px;
   margin-right: 10px;
   padding: 4px 12px;

--- a/src/scss/_type.scss
+++ b/src/scss/_type.scss
@@ -4,7 +4,7 @@
   @include DistinctDisplay;
 
   color: $primary-black;
-  font-weight: 400;
+  font-variation-settings: 'wght' 400;
 }
 
 @mixin titleText {
@@ -52,7 +52,7 @@
 
   color: $color;
   font-size: $size;
-  font-weight: 400;
+  font-variation-settings: 'wght' 400;
   line-height: $line-height;
   text-decoration: none;
   text-transform: $transform-style;
@@ -69,9 +69,10 @@
 @mixin labelText($label) {
   @include Montserrat;
 
+  font-variation-settings: 'wght' 600;
+
   @if $label == 'link' {
     font-size: $link-label-size;
-    font-weight: 600;
     letter-spacing: 1px;
     line-height: $link-label-line-height;
     text-transform: uppercase;
@@ -79,7 +80,6 @@
 
   @if $label == 'button' {
     font-size: $button-label-size;
-    font-weight: 600;
     letter-spacing: 0;
     line-height: $button-label-line-height;
     text-transform: capitalize;
@@ -87,7 +87,6 @@
 
   @if $label == 'email' {
     font-size: $email-label-size;
-    font-weight: 600;
     letter-spacing: 0.0625rem;
     line-height: 1.25;
     text-transform: lowercase;
@@ -95,14 +94,14 @@
 
   @if $label == 'label' {
     font-size: $text-label-size;
-    font-weight: 500;
+    font-variation-settings: 'wght' 500;
     letter-spacing: 0.0625rem;
     line-height: 1.25;
   }
 
   @if $label == 'badge' {
     font-size: $badge-label-size;
-    font-weight: 500;
+    font-variation-settings: 'wght' 500;
     letter-spacing: 0;
     line-height: $badge-label-line-height;
     text-transform: uppercase;
@@ -209,7 +208,7 @@
     @include DistinctDisplay;
 
     font-size: $snw-header-link-size;
-    font-weight: 400;
+    font-variation-settings: 'wght' 400;
     letter-spacing: 1px;
     line-height: $snw-header-link-line-height;
     text-transform: uppercase;
@@ -219,7 +218,7 @@
     @include Montserrat;
 
     font-size: $snw-flyout-link-size;
-    font-weight: 400;
+    font-variation-settings: 'wght' 400;
     letter-spacing: 1px;
     line-height: $snw-flyout-link-line-height;
     text-transform: capitalize;

--- a/src/story-styles.scss
+++ b/src/story-styles.scss
@@ -12,6 +12,17 @@
 // 📑 Pages
 @import 'pages/page';
 
+strong,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-variation-settings: 'wght' 700;
+  font-variation-settings: 'wght' unset;
+}
+
 // Design markdown styles
 .h1 {
   @include hText($heading-size1, null, uppercase);
@@ -74,7 +85,7 @@ details {
   color: #66bf3c;
   display: inline-block;
   font-size: 11px;
-  font-weight: 700;
+  font-variation-settings: 'wght' 700;
   line-height: 12px;
   margin-right: 10px;
   padding: 4px 12px;

--- a/src/story-styles.scss
+++ b/src/story-styles.scss
@@ -20,7 +20,8 @@ h4,
 h5,
 h6 {
   font-variation-settings: 'wght' 700;
-  font-variation-settings: 'wght' unset;
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list */
+  font-weight: unset;
 }
 
 // Design markdown styles

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -12,6 +12,15 @@ module.exports = {
     'scss/at-mixin-pattern': null,
     'media-feature-range-notation': 'prefix',
     'color-function-notation': 'legacy',
+    'declaration-property-value-disallowed-list': [
+      {
+        'font-weight': [/./],
+      },
+      {
+        message:
+          'Font-weight does not work with our variable fonts in Safari. Use "font-variation-settings: "wght" <weight>" instead.',
+      },
+    ],
     'selector-class-pattern': [
       '^[a-z]([-]?[a-z0-9]+)*(__[a-z0-9]([-]?[a-z0-9]+)*)?(--[a-z0-9]([-]?[a-z0-9]+)*)?$',
       {


### PR DESCRIPTION
**Jira ticket**

[Jira Ticket ID](https://phillipsauctions.atlassian.net/browse/L3-3693)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/5f48ee33-71dc-4d6d-a725-f11f2ff82225) | ![image](https://github.com/user-attachments/assets/e745b8f3-ac1c-4183-b733-2bbed6f55bc9) |

**Summary**

Font-weight > 500 looks incorrect with variable fonts on Safari

**Change List (describe the changes made to the files)**

- change(*.scss): change `font-weight` to use variable font  `wght` property instead
- change(type-tokens): remove some redundant examples
- change(eslint): put in rule to prevent future `font-weight` props

**Acceptance Test (how to verify the PR)**

- Open the "Type Tokens" story on Safari, verify any font-weight: 600 or font-weight: 700 tokens look correct and match Chrome
- Check all the `<Text` component variants comparing Safari and Chrome and they should look the same.
- Check the eslint rule catches a `font-weight: 700;`

**Regression Test**

- Double-check on Chrome, Firefox, and Edge that no regressions

**Evidence of testing**

- See screenshots above

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
