### PR TITLE
chore(lotdetails): L3-3145 lot details seldon follow ons

### DIFF
--- a/src/components/Carousel/CarouselItem.tsx
+++ b/src/components/Carousel/CarouselItem.tsx
@@ -19,7 +19,7 @@ const CarouselItem = forwardRef<HTMLDivElement, CarouselItemProps>(({ className,
   return (
     <div
       ref={ref}
-      role="group"
+      role={props.onClick ? 'button' : 'group'}
       aria-roledescription="slide"
       className={classNames(`${baseClassName}-item`, className, {
         [`${baseClassName}-item--gap-${columnGap}`]: !!columnGap,

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -22,6 +22,10 @@ export interface ModalProps extends ReactModal.Props {
    * The children of the modal
    */
   children: React.ReactNode;
+  /**
+   * className for the modal
+   */
+  className?: string;
 }
 
 /**
@@ -56,6 +60,8 @@ const Modal = ({
       overlayClassName={classnames(`${baseClassName}__overlay`)}
       ariaHideApp={isOpen}
       testId={testId}
+      onAfterOpen={() => (document.body.style.overflow = 'hidden')}
+      onAfterClose={() => (document.body.style.overflow = 'unset')}
       {...props}
     >
       <IconButton


### PR DESCRIPTION
**Jira ticket**

[L3-3145](https://phillipsauctions.atlassian.net/browse/L3-3145)

**Screenshots**
| Before | After |
| ------ | ----- |
| Paste Before Image | Paste After Image |

**Summary**

follow ons from comments in https://github.com/PhillipsAuctionHouse/phillips-public-remix/pull/369

Add high-level overview of the changes that were made and explanation of WHY they were made

**Change List (describe the changes made to the files)**

- Additions, Changes, and Removals

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-3145]: https://phillipsauctions.atlassian.net/browse/L3-3145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ