### PR TITLE
fix(breadcrumb): L3-3900 breadcrumb style fixes

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -11,7 +11,7 @@ export default meta;
 const items = [
   {
     href: '',
-    label: 'Art, Modern to Contemporary',
+    label: 'Art, Modern to Contemporary With Really Really Really Really Really ReallyLong Text that forces Truncation',
   },
   {
     href: '',
@@ -22,7 +22,7 @@ const items = [
     label: 'Lot 1',
   },
 ];
-export const Playground = (props: BreadcrumbProps) => <Breadcrumb {...props} />;
+export const Playground = (props: BreadcrumbProps) => <Breadcrumb truncateIndex={0} {...props} />;
 
 Playground.args = {
   items,

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -53,23 +53,22 @@ describe('Breadcrumb component', () => {
   });
 
   it('truncates specific item based on truncateIndex', () => {
-    render(<Breadcrumb items={items} truncateIndex={1} truncateLength={15} />);
-
-    // Check if the truncated item is displayed correctly
-    const truncatedItem = screen.getByText(/Modern & Contem.../i);
+    render(<Breadcrumb items={items} truncateIndex={1} />);
+    // Check that the full item is rendered for screen readers
+    const truncatedItem = screen.getByRole('listitem', { name: 'Modern & Contemporary Art Evening Sale - Test3' });
     expect(truncatedItem).toBeInTheDocument();
-
-    // Check that the full item is not rendered
-    const fullLabelItem = screen.queryByText(/Modern & Contemporary Art Evening Sale - Test3/i);
-    expect(fullLabelItem).not.toBeInTheDocument();
+    expect(truncatedItem).toHaveClass('seldon-breadcrumb--truncate');
+    const fullLabelItem = screen.getByRole('listitem', { name: 'Art, Modern to Contemporary' });
+    expect(fullLabelItem).toBeInTheDocument();
+    expect(fullLabelItem).not.toHaveClass('seldon-breadcrumb--truncate');
   });
 
   it('does not truncate if truncateIndex is not provided', () => {
     render(<Breadcrumb items={items} />);
 
-    // Check that the full long label is rendered
-    const fullLabelItem = screen.getByText(/Modern & Contemporary Art Evening Sale - Test3/i);
-    expect(fullLabelItem).toBeInTheDocument();
+    const truncatedItem = screen.getByRole('listitem', { name: 'Modern & Contemporary Art Evening Sale - Test3' });
+    expect(truncatedItem).toBeInTheDocument();
+    expect(truncatedItem).not.toHaveClass('seldon-breadcrumb--truncate');
   });
 
   test('renders breadcrumb items in desktop view', () => {

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getCommonProps } from '../../utils';
+import { getCommonProps, px } from '../../utils';
 import classnames from 'classnames';
 import BreadcrumbItem, { BreadcrumbItemProps } from './BreadcrumbItem';
 import { SSRMediaQuery } from '../../providers/utils';
@@ -20,10 +20,6 @@ export interface BreadcrumbProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   truncateIndex?: number;
   /**
-   * Max length for truncation
-   */
-  truncateLength?: number;
-  /**
    * Custom element to render for the link
    */
   linkElement?: React.ElementType<React.ComponentProps<'a'>>;
@@ -41,7 +37,6 @@ const Breadcrumb = ({
   className,
   items = [],
   truncateIndex,
-  truncateLength = 10,
   linkElement: CustomElement = 'a',
   ...props
 }: BreadcrumbProps) => {
@@ -54,10 +49,10 @@ const Breadcrumb = ({
       <SSRMediaQuery.Media lessThan="md">
         <CustomElement
           href={items[1].href ? items[1].href : '/'}
-          className="back-button"
+          className={`${px}-icon-button ${px}-icon-button--secondary`} // apply button styles though it's a link
           data-testid={`${id}-back-button`}
         >
-          <ArrowPrevIcon />
+          <ArrowPrevIcon className={`${baseClassName}__back-button`} />
         </CustomElement>
       </SSRMediaQuery.Media>
       {/* This is not visible when in mobile breakpoint */}
@@ -71,7 +66,6 @@ const Breadcrumb = ({
               isCurrent={items.length - 1 === index}
               key={item.label}
               isTruncateText={truncateIndex === index}
-              truncateLength={truncateLength}
             />
           ))}
         </ol>

--- a/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -20,11 +20,6 @@ export interface BreadcrumbItemProps extends React.HTMLAttributes<HTMLDivElement
    * truncate text boolean
    * */
   isTruncateText?: boolean;
-
-  /**
-   * Length to which the text should be truncated
-   * */
-  truncateLength?: number;
   /**
    * Custom element to render for the link
    */
@@ -37,7 +32,6 @@ const BreadcrumbItem = ({
   label,
   isCurrent = false,
   isTruncateText = false,
-  truncateLength = 30,
   element: CustomElement = 'a',
   ...props
 }: BreadcrumbItemProps) => {
@@ -45,12 +39,11 @@ const BreadcrumbItem = ({
   const ariaCurrent = !isCurrent ? false : 'page';
   const currentHref = !isCurrent ? href : '';
 
-  const getTruncatedLabel = () => {
-    return label && label.length > truncateLength ? `${label.slice(0, truncateLength)}...` : label;
-  };
-
   return (
-    <li>
+    <li
+      aria-label={label}
+      className={classnames(`${baseClassName}__item`, { [`${baseClassName}--truncate`]: isTruncateText })}
+    >
       {isCurrent ? (
         <span className={classnames(baseClassName, className, { [`${baseClassName}--current`]: isCurrent })}>
           {label}
@@ -58,15 +51,17 @@ const BreadcrumbItem = ({
       ) : (
         <CustomElement
           aria-current={ariaCurrent}
-          className={classnames(baseClassName, className, { [`${baseClassName}--current`]: isCurrent })}
+          className={classnames(baseClassName, className, {
+            [`${baseClassName}--current`]: isCurrent,
+          })}
           href={currentHref}
           {...commonProps}
         >
-          {isTruncateText ? getTruncatedLabel() : label}
+          {label}
         </CustomElement>
       )}
 
-      {!isCurrent ? <ChevronNextIcon /> : null}
+      {!isCurrent ? <ChevronNextIcon className={`${baseClassName}__chevron`} /> : null}
     </li>
   );
 };

--- a/src/components/Breadcrumb/_breadcrumb.scss
+++ b/src/components/Breadcrumb/_breadcrumb.scss
@@ -5,10 +5,6 @@
 
   color: $pure-black;
 
-  @media (max-width: $breakpoint-sm) {
-    display: none;
-  }
-
   .back-button {
     align-items: center;
     background-color: transparent;

--- a/src/components/Breadcrumb/_breadcrumb.scss
+++ b/src/components/Breadcrumb/_breadcrumb.scss
@@ -5,57 +5,66 @@
 
   color: $pure-black;
 
-  .back-button {
-    align-items: center;
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
-    display: flex;
-    height: 44px;
-    justify-content: center;
-    width: 44px;
-
+  &__back-button {
     svg {
-      height: 24px;
-      width: 24px;
+      height: 1rem;
+      width: 1rem;
     }
+  }
+
+  &__item {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    flex-shrink: 0;
+
+    a {
+      margin: $margin-sm;
+      outline: none;
+      text-decoration: none;
+      text-wrap: nowrap;
+
+      &:hover {
+        color: $button-hover;
+        text-decoration: none;
+      }
+
+      &:focus-visible {
+        border-radius: 5px;
+        outline: 1px solid $medium-gray;
+      }
+    }
+
+    span {
+      margin: $margin-sm;
+    }
+  }
+
+  &__chevron {
+    height: 1rem;
+    width: 1rem;
   }
 
   ol {
     display: flex;
     flex-direction: row;
     padding: 0;
+  }
 
-    li {
-      align-items: center;
-      display: flex;
-      flex-direction: row;
+  &--truncate {
+    flex-shrink: 1;
+    overflow: hidden;
 
-      svg {
-        height: 16px;
-        width: 16px;
-      }
-
-      a {
-        margin: $margin-sm;
-        overflow: hidden;
-        text-decoration: none;
-        text-wrap: nowrap;
-
-        &:hover {
-          color: $button-hover;
-          text-decoration: none;
-        }
-      }
-
-      span {
-        margin: $margin-sm;
-      }
+    a {
+      flex-shrink: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 
   &--current {
     color: $primary-black;
     font-variation-settings: 'wght' 700;
+    white-space: nowrap;
   }
 }

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -54,7 +54,7 @@ const Drawer = ({ className, isOpen = false, onClose = noOp, children, ...props 
               className={classnames(`${baseClassName}__close`)}
               aria-label="Close"
               data-testid="drawer-close"
-              variant={ButtonVariants.tertiary}
+              variant={ButtonVariants.secondary}
             >
               <CloseIcon />
             </IconButton>

--- a/src/components/IconButton/_iconButton.scss
+++ b/src/components/IconButton/_iconButton.scss
@@ -63,18 +63,17 @@
   }
 
   &--secondary,
-  &--tertiary {
+  &--tertiary.#{$px}-icon-button {
     height: 28px;
+    padding: $spacing-xsm;
     width: 28px;
 
     & > svg {
       fill: $pure-black;
-      height: 100%;
-      height: 1rem;
+      height: 1.25rem;
       margin-inline-end: unset;
       position: absolute;
-      width: 100%;
-      width: 1rem;
+      width: 1.25rem;
 
       path {
         fill: $pure-black;
@@ -83,7 +82,7 @@
   }
 
   &--tertiary {
-    &:focus {
+    &:focus-visible {
       border-radius: 100px;
     }
   }

--- a/src/components/IconButton/_iconButton.scss
+++ b/src/components/IconButton/_iconButton.scss
@@ -1,11 +1,10 @@
 @use '#scss/allPartials' as *;
 
 .#{$px}-icon-button {
+  align-items: center;
+  display: flex;
+  justify-content: center;
   padding: 0;
-
-  & > svg {
-    position: absolute;
-  }
 
   &:focus-visible {
     &:focus-visible {
@@ -27,11 +26,8 @@
 
     & > svg {
       fill: $pure-black;
-      height: 100%;
       height: 1.5rem;
       margin-inline-end: unset;
-      position: absolute;
-      width: 100%;
       width: 1.5rem;
 
       path {
@@ -68,6 +64,10 @@
     padding: $spacing-xsm;
     width: 28px;
 
+    &:focus-visible {
+      border-radius: 100px;
+    }
+
     & > svg {
       fill: $pure-black;
       height: 1.25rem;
@@ -78,12 +78,6 @@
       path {
         fill: $pure-black;
       }
-    }
-  }
-
-  &--tertiary {
-    &:focus-visible {
-      border-radius: 100px;
     }
   }
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -69,7 +69,7 @@ const Modal = ({
         onClick={onClose}
         aria-label="Close Modal"
         className={classnames(`${baseClassName}__close`)}
-        variant={ButtonVariants.tertiary}
+        variant={ButtonVariants.secondary}
       >
         <CloseIcon />
       </IconButton>

--- a/src/components/Modal/_modal.scss
+++ b/src/components/Modal/_modal.scss
@@ -6,7 +6,7 @@
   max-height: 100%;
   max-width: 100%;
   overflow: auto;
-  padding: 2rem;
+  padding: $padding-md;
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta } from '@storybook/react';
 import { useState } from 'react';
 
-import Pagination, { PaginationProps } from './Pagination';
+import Pagination, { PaginationOptionValue, PaginationProps } from './Pagination';
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 const meta = {
   title: 'Components/Pagination',
@@ -35,7 +35,7 @@ const argTypes = {
 
 export const Playground = ({ playgroundWidth, onChange, ...args }: StoryProps) => {
   // Parent component is in charge of the state management
-  const [value, setValue] = useState<string>(lotOptions[0]);
+  const [value, setValue] = useState<PaginationOptionValue>(lotOptions[0]);
 
   return (
     <div style={{ width: playgroundWidth, margin: '1rem' }}>

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -14,7 +14,13 @@ interface StoryProps extends PaginationProps {
   playgroundWidth: string;
 }
 
-const lotOptions = ['Lot 1', 'Lot 2', 'Lot 3', 'Lot 4', 'Lot 5'];
+const lotOptions = [
+  { label: 'Lot 1', value: 1 },
+  { label: 'Lot 2', value: 2 },
+  { label: 'Lot 3', value: 3 },
+  { label: 'Lot 4', value: 4 },
+  { label: 'Lot 5', value: 5 },
+];
 
 const argTypes = {
   disabled: {
@@ -32,10 +38,9 @@ const argTypes = {
     control: { type: 'range', min: 200, max: 300, step: 50 },
   },
 };
-
 export const Playground = ({ playgroundWidth, onChange, ...args }: StoryProps) => {
   // Parent component is in charge of the state management
-  const [value, setValue] = useState<PaginationOptionValue>(lotOptions[0]);
+  const [value, setValue] = useState<PaginationOptionValue>(lotOptions[0].value ?? lotOptions[0]);
 
   return (
     <div style={{ width: playgroundWidth, margin: '1rem' }}>
@@ -52,6 +57,37 @@ export const Playground = ({ playgroundWidth, onChange, ...args }: StoryProps) =
     </div>
   );
 };
+
+export const StringOptionsPlayground = ({ playgroundWidth, onChange, ...args }: StoryProps) => {
+  const stringOptions = ['Lot 1', 'Lot 2', 'Lot 3', 'Lot 4', 'Lot 5'];
+  const [value, setValue] = useState<string>(stringOptions[0]);
+
+  return (
+    <div style={{ width: playgroundWidth, margin: '1rem' }}>
+      <Pagination
+        {...args}
+        id="Pagination-2"
+        options={stringOptions}
+        value={value}
+        onChange={(value) => {
+          setValue(value.toString());
+          onChange(value);
+        }}
+      ></Pagination>
+    </div>
+  );
+};
+
+StringOptionsPlayground.args = {
+  playgroundWidth: 200,
+  className: 'pagination-test-class',
+  isDisabled: false,
+  onChange: (selectedValue: string) => {
+    console.log('selected value >', selectedValue);
+  },
+};
+
+StringOptionsPlayground.argTypes = argTypes;
 
 Playground.args = {
   playgroundWidth: 200,

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 import { render, screen, waitFor, renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { runCommonTests } from '../../utils/testUtils';
-import Pagination from './Pagination';
+import Pagination, { PaginationOptionValue } from './Pagination';
 
-const useMockState = (value: string) => {
+const useMockState = (value: PaginationOptionValue) => {
   const [mockState, setMockState] = useState(value);
   return {
     mockState,
@@ -18,10 +18,124 @@ describe('A Pagination', () => {
   const reqProps = { id: 'test-id' };
   const lotOptions = ['Lot 1', 'Lot 2', 'Lot 3', 'Lot 4', 'Lot 5'];
 
-  it('will render a value if passed', () => {
-    render(<Pagination {...reqProps} value="Lot 2" options={lotOptions} onChange={vi.fn()}></Pagination>);
-    const selectValue = (screen.getByTestId('test-id-select-button') as HTMLSelectElement).value;
-    expect(selectValue).toEqual('Lot 2');
+  describe('string options', () => {
+    it('will render a value if passed', () => {
+      render(<Pagination {...reqProps} value="Lot 2" options={lotOptions} onChange={vi.fn()}></Pagination>);
+      const selectValue = (screen.getByTestId('test-id-select-button') as HTMLSelectElement).value;
+      expect(selectValue).toEqual('Lot 2');
+    });
+
+    it('will cycle to last elment if user clicks Previous button on first element', async () => {
+      const { result } = renderHook(() => useMockState('Lot 1'));
+      const { mockState, setMockState } = result.current;
+      render(<Pagination {...reqProps} value={mockState} options={lotOptions} onChange={setMockState}></Pagination>);
+      await userEvent.click(screen.getByTestId('test-id-previous-button'));
+      expect(result.current.mockState).toEqual('Lot 5');
+    });
+
+    it('will cycle to first elment if user clicks Next button on last element', async () => {
+      const { result } = renderHook(() => useMockState('Lot 5'));
+      const { mockState, setMockState } = result.current;
+      render(<Pagination {...reqProps} value={mockState} options={lotOptions} onChange={setMockState}></Pagination>);
+      await userEvent.click(screen.getByTestId('test-id-next-button'));
+      expect(result.current.mockState).toEqual('Lot 1');
+    });
+
+    it('will trigger onChange if the user selects new option on dropdown, Previous button and, or Next button', async () => {
+      const { result } = renderHook(() => useMockState('Lot 2'));
+      const { mockState, setMockState } = result.current;
+      render(<Pagination {...reqProps} value={mockState} options={lotOptions} onChange={setMockState}></Pagination>);
+      await userEvent.click(screen.getByTestId('test-id-previous-button'));
+      await userEvent.selectOptions(screen.getByTestId('test-id-select-button'), ['Lot 3']);
+      expect(result.current.mockState).toEqual('Lot 3');
+    });
+  });
+
+  describe('number options', () => {
+    const lotOptionsNumbers = [1, 2, 3, 4, 5];
+    it('will render a value if passed', () => {
+      render(<Pagination {...reqProps} value={2} options={lotOptionsNumbers} onChange={vi.fn()}></Pagination>);
+      const selectValue = (screen.getByTestId('test-id-select-button') as HTMLSelectElement).value;
+      expect(selectValue).toEqual('2');
+    });
+
+    it('will cycle to last elment if user clicks Previous button on first element', async () => {
+      const { result } = renderHook(() => useMockState(1));
+      const { mockState, setMockState } = result.current;
+      render(
+        <Pagination {...reqProps} value={mockState} options={lotOptionsNumbers} onChange={setMockState}></Pagination>,
+      );
+      await userEvent.click(screen.getByTestId('test-id-previous-button'));
+      expect(result.current.mockState).toEqual(5);
+    });
+
+    it('will cycle to first elment if user clicks Next button on last element', async () => {
+      const { result } = renderHook(() => useMockState(5));
+      const { mockState, setMockState } = result.current;
+      render(
+        <Pagination {...reqProps} value={mockState} options={lotOptionsNumbers} onChange={setMockState}></Pagination>,
+      );
+      await userEvent.click(screen.getByTestId('test-id-next-button'));
+      expect(result.current.mockState).toEqual(1);
+    });
+
+    it('will trigger onChange if the user selects new option on dropdown, Previous button and, or Next button', async () => {
+      const { result } = renderHook(() => useMockState(2));
+      const { mockState, setMockState } = result.current;
+      render(
+        <Pagination {...reqProps} value={mockState} options={lotOptionsNumbers} onChange={setMockState}></Pagination>,
+      );
+      await userEvent.click(screen.getByTestId('test-id-previous-button'));
+      await userEvent.selectOptions(screen.getByTestId('test-id-select-button'), ['3']);
+      expect(result.current.mockState).toEqual(3);
+    });
+  });
+
+  describe('PaginationOption options', () => {
+    const lotOptionsObjects = [
+      { label: 'Lot 1', value: '1' },
+      { label: 'Lot 2', value: '2' },
+      { label: 'Lot 3', value: '3' },
+      { label: 'Lot 4', value: '4' },
+      { label: 'Lot 5', value: '5' },
+    ];
+
+    it('will render a value if passed', () => {
+      render(<Pagination {...reqProps} value="2" options={lotOptionsObjects} onChange={vi.fn()}></Pagination>);
+      const selectValue = (screen.getByTestId('test-id-select-button') as HTMLSelectElement).value;
+      expect(selectValue).toEqual('2');
+    });
+
+    it('will cycle to last element if user clicks Previous button on first element', async () => {
+      const { result } = renderHook(() => useMockState('1'));
+      const { mockState, setMockState } = result.current;
+      render(
+        <Pagination {...reqProps} value={mockState} options={lotOptionsObjects} onChange={setMockState}></Pagination>,
+      );
+      await userEvent.click(screen.getByTestId('test-id-previous-button'));
+      expect(result.current.mockState).toEqual('5');
+    });
+
+    it('will cycle to first element if user clicks Next button on last element', async () => {
+      const { result } = renderHook(() => useMockState('5'));
+      const { mockState, setMockState } = result.current;
+      render(
+        <Pagination {...reqProps} value={mockState} options={lotOptionsObjects} onChange={setMockState}></Pagination>,
+      );
+      await userEvent.click(screen.getByTestId('test-id-next-button'));
+      expect(result.current.mockState).toEqual('1');
+    });
+
+    it('will trigger onChange if the user selects new option on dropdown, Previous button and, or Next button', async () => {
+      const { result } = renderHook(() => useMockState('2'));
+      const { mockState, setMockState } = result.current;
+      render(
+        <Pagination {...reqProps} value={mockState} options={lotOptionsObjects} onChange={setMockState}></Pagination>,
+      );
+      await userEvent.click(screen.getByTestId('test-id-previous-button'));
+      await userEvent.selectOptions(screen.getByTestId('test-id-select-button'), ['3']);
+      expect(result.current.mockState).toEqual('3');
+    });
   });
 
   it('will not be interactive if isDisabled', async () => {
@@ -49,30 +163,6 @@ describe('A Pagination', () => {
     await waitFor(() => expect(mockedOnChange.mock.calls).toHaveLength(0));
   });
 
-  it('will cycle to last elment if user clicks Previous button on first element', async () => {
-    const { result } = renderHook(() => useMockState('Lot 1'));
-    const { mockState, setMockState } = result.current;
-    render(<Pagination {...reqProps} value={mockState} options={lotOptions} onChange={setMockState}></Pagination>);
-    await userEvent.click(screen.getByTestId('test-id-previous-button'));
-    expect(result.current.mockState).toEqual('Lot 5');
-  });
-
-  it('will cycle to first elment if user clicks Next button on last element', async () => {
-    const { result } = renderHook(() => useMockState('Lot 5'));
-    const { mockState, setMockState } = result.current;
-    render(<Pagination {...reqProps} value={mockState} options={lotOptions} onChange={setMockState}></Pagination>);
-    await userEvent.click(screen.getByTestId('test-id-next-button'));
-    expect(result.current.mockState).toEqual('Lot 1');
-  });
-
-  it('will trigger onChange if the user selects new option on dropdown, Previous button and, or Next button', async () => {
-    const { result } = renderHook(() => useMockState('Lot 2'));
-    const { mockState, setMockState } = result.current;
-    render(<Pagination {...reqProps} value={mockState} options={lotOptions} onChange={setMockState}></Pagination>);
-    await userEvent.click(screen.getByTestId('test-id-previous-button'));
-    await userEvent.selectOptions(screen.getByTestId('test-id-select-button'), ['Lot 3']);
-    expect(result.current.mockState).toEqual('Lot 3');
-  });
   it('renders translated text', () => {
     render(
       <Pagination

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -35,7 +35,7 @@
         cursor: pointer;
       }
 
-      &:focus {
+      &:focus-visible {
         outline: 1px solid $medium-gray;
       }
     }

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -49,11 +49,9 @@
 
 .#{$px}__pagination-button {
   svg {
+    fill: $pure-black;
+    height: 2rem;
     width: 2rem;
-
-    @include media($size-md, $type: 'max') {
-      width: 1rem;
-    }
   }
 }
 

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -47,14 +47,6 @@
   }
 }
 
-.#{$px}__pagination-button {
-  svg {
-    fill: $pure-black;
-    height: 2rem;
-    width: 2rem;
-  }
-}
-
 .#{$px}-left-arrow {
   transform: scaleX(-1);
 }

--- a/src/components/Pagination/utils.tsx
+++ b/src/components/Pagination/utils.tsx
@@ -1,0 +1,11 @@
+import { PaginationOption, PaginationOptionValue } from './Pagination';
+
+export const determineOptionValue = (option: PaginationOption | PaginationOptionValue) => {
+  return typeof option === 'string' || typeof option === 'number' ? option : option?.value;
+};
+
+export const findOptionFromSelectString = (options: (PaginationOption | PaginationOptionValue)[], value: string) => {
+  return options.find(
+    (option) => determineOptionValue(option) === value || determineOptionValue(option) === parseInt(value),
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,12 @@ export { default as Social, type SocialProps } from './patterns/Social/Social';
 export { default as ViewingsList, type ViewingsListProps } from './patterns/ViewingsList/ViewingsList';
 export { default as Modal, type ModalProps } from './components/Modal/Modal';
 export { default as Drawer } from './components/Drawer/Drawer';
-export { default as Pagination, type PaginationProps } from './components/Pagination/Pagination';
+export {
+  default as Pagination,
+  type PaginationProps,
+  type PaginationOption,
+  type PaginationOptionValue,
+} from './components/Pagination/Pagination';
 
 export {
   default as StatefulViewingsList,


### PR DESCRIPTION
**Jira ticket**

[Jira Ticket ID](https://phillipsauctions.atlassian.net/browse/L3-3900)

**Screenshots**
| Before | After |
| ------ | ----- |
| Truncates Too Early | Uses full available width |
| ![image](https://github.com/user-attachments/assets/d2a33e94-5dd2-4d3b-ab34-043367582ad6) | ![image](https://github.com/user-attachments/assets/89a5bd7e-0b2e-4777-b874-29e8a5c17a8a) |

**Summary**

Changes the prop model for `Breadcrumb` to  remove the capability to truncate at a character length as this doesn't use the full space available for the Breadcrumb at responsive screen sizes before truncating.  It instead uses css ellipsis overflow to do this so if there is room to show the full text we do.  In addition truncating at the character count is bad for accessibility because screen readers will only see the truncated text and not the full text. A few more style fixes are included

**Change List (describe the changes made to the files)**
This [PR](https://github.com/PhillipsAuctionHouse/seldon/pull/339) needs to be merged first so we only see these changes
- change(Breadcrumb/BreadcrumbItem): remove `truncateLength` prop
- change(_breadcrumb.scss): Add focus outline.  Make sure the truncation works on the truncate index with pure css overflow
- change(_iconButton): remove redundant styles, and fix `secondary` variant to be the right size

**Acceptance Test (how to verify the PR)**

- Verify the Breadcrumb story truncates the `truncateIndex` correctly and leaves the other items at full length
- Check the focus outline and hover state of the `secondary` IconButton variant.

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- With truncation
![image](https://github.com/user-attachments/assets/7b51c034-3f55-45cf-99a3-dc95e9328d09)


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
