### PR TITLE
feat(text-symbol): L3-3572 created TextSymbol component

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta } from '@storybook/react';
 import Text, { TextProps } from './Text';
 import { TextVariants } from './types';
+import { TextSymbolVariants } from '../TextSymbol/types';
+import TextSymbol from '../TextSymbol/TextSymbol';
 
 const meta = {
   title: 'Components/Text',
@@ -9,12 +11,6 @@ const meta = {
 
 export default meta;
 export const Playground = (props: TextProps) => <Text {...props} />;
-
-export const SuperScript = (props: TextProps) => (
-  <Text variant={TextVariants.heading3} superScript="ЖΟ◆" {...props}>
-    Lot number 23
-  </Text>
-);
 
 Playground.args = {
   children: 'Hi There',
@@ -27,4 +23,22 @@ Playground.argTypes = {
       type: 'select',
     },
   },
+};
+
+export const SuperScript = (props: TextProps) => <Text variant={TextVariants.heading3} {...props} />;
+
+SuperScript.args = {
+  children: 'Lot number 23',
+  superScript: <TextSymbol variant={TextSymbolVariants.lotNumber}>ЖΟ◆</TextSymbol>,
+  variant: TextVariants.heading3,
+};
+
+SuperScript.argTypes = {
+  variant: {
+    options: TextVariants,
+    control: {
+      type: 'select',
+    },
+  },
+  superScript: 'text',
 };

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -3,6 +3,8 @@ import Text, { TextProps } from './Text';
 import { TextVariants } from './types';
 import { runCommonTests } from '../../utils/testUtils';
 import { px } from '../../utils';
+import TextSymbol from '../TextSymbol/TextSymbol';
+import { TextSymbolVariants } from '../TextSymbol';
 
 describe('Text', () => {
   runCommonTests(Text, 'Text');
@@ -21,7 +23,10 @@ describe('Text', () => {
     expect(screen.getByText('Hello World')).toBeInTheDocument();
   });
   it('renders superscript correctly', () => {
-    renderText({ children: 'Hello World', superScript: 'sup' });
+    renderText({
+      children: 'Hello World',
+      superScript: <TextSymbol variant={TextSymbolVariants.lotNumber}>sup</TextSymbol>,
+    });
 
     expect(screen.getByText('Hello World')).toBeInTheDocument();
     expect(screen.getByText('sup')).toBeInTheDocument();

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -13,8 +13,10 @@ export interface TextProps extends React.HTMLAttributes<HTMLElement> {
    * The OOTB style to apply to the text
    */
   variant?: TextVariants;
-
-  superScript?: string;
+  /**
+   * Text to render special symbols
+   */
+  superScript?: React.ReactNode;
 }
 /**
  * ## Overview
@@ -30,7 +32,7 @@ const Text = ({
   className,
   element: CustomElement,
   variant = TextVariants.body2,
-  superScript = '',
+  superScript = null,
   ...props
 }: TextProps) => {
   const Component = CustomElement || determineDefaultTextElement(variant);
@@ -43,7 +45,7 @@ const Text = ({
       {...props}
     >
       {children}
-      {superScript ? <span className={classNames(`${baseClassName}--super-script`)}>{superScript}</span> : null}
+      {superScript}
     </Component>
   );
 };

--- a/src/components/TextSymbol/TextSymbol.stories.tsx
+++ b/src/components/TextSymbol/TextSymbol.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta } from '@storybook/react/*';
+import TextSymbol, { TextSymbolProps } from './TextSymbol';
+import { TextSymbolVariants } from './types';
+import Text from '../Text/Text';
+import { TextVariants } from '../Text/types';
+
+const meta = {
+  title: 'Components/TextSymbol',
+  component: TextSymbol,
+} satisfies Meta<typeof TextSymbol>;
+
+export default meta;
+export const Playground = (props: TextSymbolProps) => (
+  <Text variant={TextVariants.heading3} superScript={<TextSymbol {...props} />}>
+    Lot number 23
+  </Text>
+);
+
+Playground.args = {
+  children: 'ЖΟ◆',
+  variant: TextSymbolVariants.lotNumber,
+};
+
+Playground.argTypes = {
+  variant: {
+    options: TextSymbolVariants,
+    control: {
+      type: 'select',
+    },
+  },
+};

--- a/src/components/TextSymbol/TextSymbol.test.tsx
+++ b/src/components/TextSymbol/TextSymbol.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { runCommonTests } from '../../utils/testUtils';
+import TextSymbol, { TextSymbolProps } from './TextSymbol';
+import { px } from '../../utils';
+import { TextSymbolVariants } from './types';
+
+describe('TextSymbol', () => {
+  runCommonTests(TextSymbol, 'TextSymbol');
+  const renderTextSymbol = (props: TextSymbolProps) => {
+    render(<TextSymbol {...props} />);
+  };
+
+  it('renders children correctly', () => {
+    renderTextSymbol({ children: 'Hello World' });
+
+    expect(screen.getByText('Hello World')).toBeInTheDocument();
+  });
+
+  it('applies the default variant correctly', () => {
+    renderTextSymbol({ children: 'Default Variant' });
+
+    expect(screen.getByText('Default Variant')).toHaveClass(`${px}-text-symbol--lotNumber`);
+  });
+
+  it('applies the estimation variant correctly', () => {
+    renderTextSymbol({ children: 'Estimation Variant', variant: TextSymbolVariants.estimation });
+
+    expect(screen.getByText('Estimation Variant')).toHaveClass(`${px}-text-symbol--estimation`);
+  });
+});

--- a/src/components/TextSymbol/TextSymbol.tsx
+++ b/src/components/TextSymbol/TextSymbol.tsx
@@ -1,0 +1,23 @@
+import classNames from 'classnames';
+import { getCommonProps } from '../../utils';
+import { TextSymbolVariants } from './types';
+import './_textSymbol.scss';
+
+export interface TextSymbolProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * The varian of the text symbol which will determine the position and spacing
+   */
+  variant?: TextSymbolVariants;
+}
+
+const TextSymbol = ({ children, variant = TextSymbolVariants.lotNumber, className, ...props }: TextSymbolProps) => {
+  const { className: baseClassName, ...commonProps } = getCommonProps(props, 'TextSymbol');
+
+  return (
+    <span {...commonProps} className={classNames(baseClassName, className, `${baseClassName}--${variant}`)} {...props}>
+      {children}
+    </span>
+  );
+};
+
+export default TextSymbol;

--- a/src/components/TextSymbol/_textSymbol.scss
+++ b/src/components/TextSymbol/_textSymbol.scss
@@ -1,0 +1,14 @@
+@use '#scss/allPartials' as *;
+
+.#{$px}-text-symbol {
+  &--estimation {
+    margin-left: 0.25rem;
+    vertical-align: middle;
+  }
+
+  &--lotNumber {
+    font-size: 60%;
+    margin-left: $spacing-xsm;
+    vertical-align: super;
+  }
+}

--- a/src/components/TextSymbol/index.ts
+++ b/src/components/TextSymbol/index.ts
@@ -1,0 +1,2 @@
+export { TextSymbolVariants } from './types';
+export { default as TextSymbols, type TextSymbolProps } from './TextSymbol';

--- a/src/components/TextSymbol/types.ts
+++ b/src/components/TextSymbol/types.ts
@@ -1,0 +1,4 @@
+export enum TextSymbolVariants {
+  estimation = 'estimation',
+  lotNumber = 'lotNumber',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export {
   type StatefulViewingsListProps,
 } from './patterns/ViewingsList/StatefulViewingsList';
 export * from './components/Text';
+export * from './components/TextSymbol';
 // export* from './components/HTMLParser';
 export * from './components/Accordion';
 export { default as UserManagement, type UserManagementProps } from './patterns/UserManagement/UserManagement';


### PR DESCRIPTION
**Jira ticket**

[L3-3572](https://phillipsauctions.atlassian.net/browse/L3-3572)

**Screenshots**
| Before | After |
| ------ | ----- |
| NaN | ![image](https://github.com/user-attachments/assets/3b1d6281-f75d-457b-8961-056062a1f97a) |

**Summary**

Extracted `TextSymbol` component from `Text` component

**Change List (describe the changes made to the files)**

- src/components/Text/Text.tsx: extracted `TextSymbol` from `Text` component
- src/components/TextSymbol/TextSymbol.tsx: created `TextSymbol` component

**Acceptance Test (how to verify the PR)**

- go to http://localhost:6006/?path=/docs/components-textsymbol--overview
- verify that component exists

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
