### PR TITLE
fix(accordion): L3-3154 accordion label and icon style fixes

### DIFF
--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -92,13 +92,13 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  opacity: 0.75;
 
   &--hoverable {
     cursor: pointer;
 
-    &:hover {
-      opacity: 1;
+    &:hover,
+    &:focus-visible {
+      opacity: 0.75;
     }
   }
 
@@ -106,7 +106,7 @@
     flex: auto;
     font-variation-settings: 'wght' 600;
 
-    @include text($body2);
+    @include text($string2);
   }
 
   &__text--lg {
@@ -115,13 +115,39 @@
 
   &__icon {
     flex: initial;
-    height: 1.5rem;
+    height: 0.875rem;
     width: 1.5rem;
   }
 
   &__icon--lg {
-    height: 2rem;
+    height: 1.5rem;
     width: 2rem;
+  }
+
+  @include media($breakpoint-md) {
+    &__icon {
+      flex: initial;
+      height: 1rem;
+      width: 1.5rem;
+    }
+
+    &__icon--lg {
+      height: 1.5rem;
+      width: 2rem;
+    }
+  }
+
+  @include media($breakpoint-xl) {
+    &__icon {
+      flex: initial;
+      height: 1.25rem;
+      width: 1.75rem;
+    }
+
+    &__icon--lg {
+      height: 2rem;
+      width: 3rem;
+    }
   }
 
   &--blue-fill {

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -104,9 +104,9 @@
 
   &__text {
     flex: auto;
+    font-variation-settings: 'wght' 600;
 
     @include text($body2);
-    @include DistinctDisplay;
   }
 
   &__text--lg {

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -83,8 +83,7 @@
 }
 
 @mixin media($breakpoint, $type: 'min') {
-  @if $breakpoint == $size-sm {
-    // $breakpoint-sm: 360px;
+  @if $breakpoint == $size-sm or $breakpoint == $breakpoint-sm {
     @if $type == 'min' {
       @media (min-width: $breakpoint-sm) {
         @content;
@@ -98,7 +97,7 @@
     }
   }
 
-  @if $breakpoint == $size-md {
+  @if $breakpoint == $size-md or $breakpoint == $breakpoint-md {
     // $breakpoint-md: 961px;
     @if $type == 'min' {
       @media (min-width: $breakpoint-md) {
@@ -113,7 +112,7 @@
     }
   }
 
-  @if $breakpoint == $size-lg {
+  @if $breakpoint == $size-lg or $breakpoint == $breakpoint-lg {
     // $breakpoint-lg: 1401px;
 
     @if $type == 'min' {
@@ -129,7 +128,7 @@
     }
   }
 
-  @if $breakpoint == $size-xl {
+  @if $breakpoint == $size-xl or $breakpoint == $breakpoint-xl {
     // $breakpoint-xl: 1801px;
     @if $type == 'min' {
       @media (min-width: $breakpoint-xl) {

--- a/src/site-furniture/Header/_header.scss
+++ b/src/site-furniture/Header/_header.scss
@@ -178,4 +178,10 @@
       width: 100%;
     }
   }
+
+  .#{$px}-accordion-item-label__icon {
+    // slightly larger in header mobile than default
+    height: 1rem;
+    width: 1.5rem;
+  }
 }


### PR DESCRIPTION
**Jira ticket**

[L3-3154](https://phillipsauctions.atlassian.net/browse/L3-3154)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/75b7906e-ccde-43f3-8ab6-c1daa03e37bb) | ![image](https://github.com/user-attachments/assets/60c86b8c-27d9-4dbf-9a88-37193b4df10a) |

**Summary**

While adding the Lot Details Accordion to Remix, I noticed that the accordion Label styles didn't match the Figma

**Change List (describe the changes made to the files)**

- change(accordion): fix fonts, colors and icon sizes for the AccordionItem
- change(utils): make it support both `$size-sm` or `$breakpoint-sm` because I keep getting confused and it fails silently
- change(header): need to make the accordion icons bigger just for the mobile header

**Acceptance Test (how to verify the PR)**

- Test the Small accordion story at each breakpoint and make sure they match the [Figma](https://www.figma.com/design/dGJDhTBtxCrcPrdo6Dl9DN/RW---LIVE-Lot-Details-(PDP)?node-id=262-6941&t=ldzMBnywElhDgt6m-4) for Lot Details

**Regression Test**

- Confirm that the Header mobile accordion items match the size of the Figma site furniture Header component
- Confirm that the Footer accordion items match the size of the site furniture Footer component.

**Evidence of testing**
![image](https://github.com/user-attachments/assets/3338fc80-42c9-4816-bffd-d6075263cf7c)
![image](https://github.com/user-attachments/assets/bf28a59c-db9e-4961-a576-23011a5788de)
![image](https://github.com/user-attachments/assets/d9891a4d-0444-4c25-aef2-77f36a2118f0)


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-3154]: https://phillipsauctions.atlassian.net/browse/L3-3154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ