### PR TITLE
fix(accordion): L3-3154 accordion item style was overriding <strong tags in CMS content

### DIFF
--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -20,7 +20,6 @@
 
   &[data-state='open'] {
     display: block;
-    font-variation-settings: 'wght' 400;
     height: auto;
   }
 


### PR DESCRIPTION


**Jira ticket**

[L3-3154](https://phillipsauctions.atlassian.net/browse/L3-3154)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/9cfa0c7d-87c8-40c8-bdca-ea54ee0c5b9d) | ![image](https://github.com/user-attachments/assets/5f3d8126-944c-4b3f-9834-8c7977424cd5) |

**Summary**

I regressed this style when I flipped to font variation settings instead of font-weight, this undoes that font variation setting for content and let the <strong> tag font-weight take over.

**Change List (describe the changes made to the files)**

- change(accordion.scss): remove unnecessary font variation settings

**Acceptance Test (how to verify the PR)**

- Verify if you put <strong> content in an accordion it renders as bols

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-3154]: https://phillipsauctions.atlassian.net/browse/L3-3154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ