### PR TITLE
fix(margins): L3-4079 remove global margin reset and set explicitly in Text component

### DIFF
--- a/src/components/LinkBlock/LinkBlock.tsx
+++ b/src/components/LinkBlock/LinkBlock.tsx
@@ -2,6 +2,7 @@ import classnames from 'classnames';
 import { getCommonProps } from '../../utils';
 import Link, { LinkProps } from '../Link/Link';
 import { LinkVariants } from '../Link/types';
+import { Text } from '../Text';
 
 export interface LinkBlockProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Props for the Link component */
@@ -28,7 +29,7 @@ const LinkBlock = ({ linkProps, description, className: classNameProp, ...props 
   return (
     <div {...commonProps} className={className} {...props}>
       <LinkComponent {...linkProps} data-testid={`${commonProps['data-testid']}-link`} variant={LinkVariants.link} />
-      <p className={`${baseClassName}__description`}>{description}</p>
+      <Text className={`${baseClassName}__description`}>{description}</Text>
     </div>
   );
 };

--- a/src/components/LinkBlock/_linkBlock.scss
+++ b/src/components/LinkBlock/_linkBlock.scss
@@ -7,7 +7,7 @@
   gap: $spacing-xsm;
   text-align: center;
 
-  &__description {
-    @include text($body2);
+  &__description.#{$px}-text {
+    margin-bottom: 0;
   }
 }

--- a/src/components/Text/_text.scss
+++ b/src/components/Text/_text.scss
@@ -1,6 +1,8 @@
 @use '#scss/allPartials' as *;
 
 .#{$px}-text {
+  margin: 0;
+
   @each $variant in $text-tokens {
     &--#{$variant} {
       @include text($variant);

--- a/src/providers/SeldonProvider/_seldonProvider.scss
+++ b/src/providers/SeldonProvider/_seldonProvider.scss
@@ -27,6 +27,7 @@
     font-weight: unset;
   }
 
+  blockquote,
   p,
   h1,
   h2,
@@ -36,7 +37,6 @@
   h6 {
     /* stylelint-disable-next-line declaration-property-value-disallowed-list */
     font-weight: unset;
-    margin-top: 0;
     overflow-wrap: break-word;
   }
 

--- a/src/site-furniture/Header/_header.scss
+++ b/src/site-furniture/Header/_header.scss
@@ -73,6 +73,7 @@
 
   &__logo {
     align-self: center;
+    margin: 0;
     padding-top: 6px; // small adjustment to center the logo
 
     svg {


### PR DESCRIPTION


**Jira ticket**

[L3-4079](https://phillipsauctions.atlassian.net/browse/L3-4079)

Should look the same except for the LinkBlock bottom margins


**Summary**

Our SeldonProvider global margin-top reset didn't work correctly so I'm removing this reset entirely and making sure all components with user-agent resets (i.e. Text components) reset their own margins.  Then each Text component sets a bottom margin based on the variant it is

**Change List (describe the changes made to the files)**

- change(LinkBlock): use our text component and override margin-bottom
- change(Text): unset all margins here instead of in the global provider reset
- change(seldonProvider): apply text resets to blockquote too
- change(header): explicitly remove margins here since the global margin reset was removed

**Acceptance Test (how to verify the PR)**

- Confirm that LinkBlock, Text and Header components look the same between the deployed seldon and localhost

**Regression Test**

- Check Mobile Header and Footer

**Evidence of testing**

LinkBlocks should not have bottom margin:
Before:
<img width="650" alt="image" src="https://github.com/user-attachments/assets/28bdff11-af36-4bc3-ae2c-da9fad52dc42">
After:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/1ba23f98-5601-42f2-9589-3ad6ef472c12">

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
