### PR TITLE
fix(lotdetails): L3-3327 fix input labels on non-mobile breakpoints, …

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -6,6 +6,7 @@ import NavigationItem from '../Navigation/NavigationItem/NavigationItem';
 import Accordion, { AccordionProps } from './Accordion';
 import AccordionItem, { AccordionItemProps } from './AccordionItem';
 import { AccordionItemVariant, AccordionVariants } from './types';
+import Button from '../Button/Button';
 
 const meta = {
   title: 'Components/Accordion',
@@ -140,5 +141,36 @@ export const AccordionSubmenu = ({ transitionTimeInMs, ...props }: AccordionProp
         </div>
       </AccordionItem>
     </Accordion>
+  );
+};
+
+export const ControlledAccordion = ({ items, ...props }: AccordionProps & { items: AccordionItemProps[] }) => {
+  const [expandedAccordionItems, setExpandedAccordionItems] = useState<string[] | undefined>();
+
+  const middleAccordionItemId = 'accordion-item-1';
+  return (
+    <div>
+      <Button
+        onClick={() =>
+          setExpandedAccordionItems(
+            expandedAccordionItems?.includes(middleAccordionItemId)
+              ? expandedAccordionItems?.filter((item) => item !== middleAccordionItemId)
+              : [...(expandedAccordionItems ?? []), middleAccordionItemId],
+          )
+        }
+      >{`${expandedAccordionItems?.includes(middleAccordionItemId) ? 'Collapse' : 'Expand'} middle accordion item`}</Button>
+      <Accordion {...props} value={expandedAccordionItems} onValueChanged={setExpandedAccordionItems}>
+        {smallTextItems.map((item, index, arr) => (
+          <AccordionItem
+            {...item}
+            isLastItem={index === arr?.length - 1}
+            key={`accordion-key-${item?.label}`}
+            id={`accordion-item-${index}`}
+          >
+            {item?.children}
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
   );
 };

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -10,9 +10,6 @@ import { AccordionItemVariant, AccordionVariants } from './types';
 const meta = {
   title: 'Components/Accordion',
   component: Accordion,
-  args: {
-    transitionTimeInMs: 250,
-  },
   argTypes: {
     variant: {
       options: Object.values(AccordionVariants),
@@ -21,7 +18,7 @@ const meta = {
       },
     },
   },
-} satisfies Meta<typeof AccordionLarge>;
+} satisfies Meta<typeof Accordion>;
 
 export default meta;
 
@@ -48,7 +45,7 @@ const largeTextItems = [
   },
 ];
 
-export const AccordionLarge = ({ transitionTimeInMs, ...props }: AccordionProps & AccordionItemProps) => (
+export const AccordionLarge = ({ transitionTimeInMs = 250, ...props }: AccordionProps & AccordionItemProps) => (
   <Accordion {...props}>
     {largeTextItems.map((item, index, arr) => (
       <AccordionItem

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -63,6 +63,48 @@ describe('Accordion', () => {
     const lockedContentElement = screen.getByText('Sign Up');
     expect(lockedContentElement).toHaveClass(`${px}-sign-up-link`);
   });
+  it('singleCollapsible variant should only allow one item to be open at a time', async () => {
+    render(
+      <Accordion variant="singleCollapsible">
+        {[
+          {
+            variation: 'sm',
+            label: 'Provenance',
+            children: <div>Lorem ipsum</div>,
+          },
+          {
+            variation: 'sm',
+            label: 'Exhibitied',
+            children: <div>Log In</div>,
+          },
+        ].map((item, index, arr) => (
+          <AccordionItem
+            {...item}
+            isLastItem={index === arr?.length - 1}
+            key={`accordion-key-${item?.label}`}
+            id={`accordion-item-${index}`}
+          >
+            {item?.children}
+          </AccordionItem>
+        ))}
+      </Accordion>,
+    );
+
+    // Should have 2 closed items
+    const accordionItemTriggers = screen.queryAllByTestId(/accordion-item-\d-trigger/);
+    expect(accordionItemTriggers).toHaveLength(2);
+    accordionItemTriggers.map((trigger) => expect(trigger).toHaveAttribute('aria-expanded', 'false'));
+
+    // After clicking first item, we should have 1 open and 1 closed item
+    await userEvent.click(screen.getByTestId('accordion-item-0-trigger'));
+    expect(screen.getByTestId('accordion-item-0-trigger')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('accordion-item-1-trigger')).toHaveAttribute('aria-expanded', 'false');
+
+    // After clicking second item, we should have 1 open and 1 closed item
+    await userEvent.click(screen.getByTestId('accordion-item-1-trigger'));
+    expect(screen.getByTestId('accordion-item-1-trigger')).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('accordion-item-0-trigger')).toHaveAttribute('aria-expanded', 'false');
+  });
 
   it('should contain the contents and expand once the label is clicked', async () => {
     const { container } = render(
@@ -112,27 +154,23 @@ describe('Accordion', () => {
     const variantProps = getAccordionVariantProps('singleCollapsible');
 
     expect(variantProps.type).toBe('single');
-    expect(variantProps.collapsible).toBe(true);
   });
 
   it('should get the correct variant props for the "singleNonCollapsible" variant', () => {
     const variantProps = getAccordionVariantProps('singleNonCollapsible');
 
     expect(variantProps.type).toBe('single');
-    expect(variantProps.collapsible).toBe(false);
   });
 
   it('should get the correct variant props for the "multiple" variant', () => {
     const variantProps = getAccordionVariantProps('multiple');
 
     expect(variantProps.type).toBe('multiple');
-    expect(variantProps.collapsible).toBeUndefined();
   });
 
   it('should default to the variant props for "multiple" if no variant is passed in', () => {
     const variantProps = getAccordionVariantProps();
 
     expect(variantProps.type).toBe('multiple');
-    expect(variantProps.collapsible).toBeUndefined();
   });
 });

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import { AccordionVariantKey } from './types';
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import classnames from 'classnames';
 import { getCommonProps } from '../../utils';
 import * as Accordion from '@radix-ui/react-accordion';
@@ -22,6 +22,14 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
    * Child element pass in to display as item content.
    */
   children?: React.ReactNode;
+  /**
+   * Array of values to set the accordion items to.
+   */
+  values?: string[];
+  /**
+   * Callback function to be called when the values change.
+   */
+  onValuesChanged?: (values: string[]) => void;
 }
 /**
  * ## Overview
@@ -32,20 +40,28 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
  *
  * [Storybook Link](https://phillips-seldon.netlify.app/?path=/docs/components-accordion--overview)
  */
-const AccordionComponent = ({ className, children, ...props }: AccordionProps) => {
-  const { className: baseClassName, ...commonProps } = getCommonProps(props, 'Accordion');
-  const variantProps = getAccordionVariantProps(props.variant);
+const AccordionComponent = forwardRef<HTMLDivElement, AccordionProps>(
+  ({ className, children, values, onValuesChanged, ...props }: AccordionProps, ref) => {
+    const { className: baseClassName, ...commonProps } = getCommonProps(props, 'Accordion');
+    const variantProps = getAccordionVariantProps(props.variant);
 
-  return (
-    <Accordion.Root
-      className={classnames(`${baseClassName}`, className)}
-      {...commonProps}
-      {...variantProps}
-      id={props?.id}
-    >
-      {children}
-    </Accordion.Root>
-  );
-};
+    return (
+      <Accordion.Root
+        className={classnames(`${baseClassName}`, className)}
+        {...commonProps}
+        {...variantProps}
+        id={props?.id}
+        ref={ref}
+        type="multiple"
+        value={values}
+        onValueChange={onValuesChanged}
+      >
+        {children}
+      </Accordion.Root>
+    );
+  },
+);
+
+AccordionComponent.displayName = 'Accordion';
 
 export default AccordionComponent;

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import { AccordionVariantKey } from './types';
 
-import React, { forwardRef } from 'react';
+import React, { ComponentProps, forwardRef } from 'react';
 import classnames from 'classnames';
 import { getCommonProps } from '../../utils';
 import * as Accordion from '@radix-ui/react-accordion';
@@ -22,14 +22,15 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
    * Child element pass in to display as item content.
    */
   children?: React.ReactNode;
+
   /**
-   * Array of values to set the accordion items to.
+   * Optionally control the expanded state of the accordion items.
    */
-  values?: string[];
+  value?: ComponentProps<typeof Accordion.Root>['value'];
   /**
-   * Callback function to be called when the values change.
+   * Callback function to be called when the expanded state of the items change.
    */
-  onValuesChanged?: (values: string[]) => void;
+  onValueChanged?: ComponentProps<typeof Accordion.Root>['onValueChange'];
 }
 /**
  * ## Overview
@@ -41,20 +42,20 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
  * [Storybook Link](https://phillips-seldon.netlify.app/?path=/docs/components-accordion--overview)
  */
 const AccordionComponent = forwardRef<HTMLDivElement, AccordionProps>(
-  ({ className, children, values, onValuesChanged, ...props }: AccordionProps, ref) => {
+  ({ className, children, variant, value, onValueChanged, ...props }: AccordionProps, ref) => {
     const { className: baseClassName, ...commonProps } = getCommonProps(props, 'Accordion');
-    const variantProps = getAccordionVariantProps(props.variant);
+    const variantProps = getAccordionVariantProps(variant, value);
 
     return (
+      // @ts-expect-error radix-ui type checking is too aggressive ans we know the values are valid
       <Accordion.Root
         className={classnames(`${baseClassName}`, className)}
         {...commonProps}
         {...variantProps}
         id={props?.id}
         ref={ref}
-        type="multiple"
-        value={values}
-        onValueChange={onValuesChanged}
+        value={value}
+        onValueChange={onValueChanged}
       >
         {children}
       </Accordion.Root>

--- a/src/components/Accordion/types.ts
+++ b/src/components/Accordion/types.ts
@@ -1,3 +1,5 @@
+import { AccordionMultipleProps, AccordionSingleProps } from '@radix-ui/react-accordion';
+
 // AccordionHeader Interface
 export interface AccordionHeaderType {
   /**
@@ -78,16 +80,11 @@ export enum AccordionVariants {
 }
 export type AccordionVariantKey = keyof typeof AccordionVariants;
 
-export enum AccordionType {
-  single = 'single',
-  multiple = 'multiple',
-}
-
 export interface AccordionVariantProps {
   /**
    * Determines whether multiple elements can be opened at the same time or not.
    */
-  type: AccordionType;
+  type: AccordionSingleProps['type'] | AccordionMultipleProps['type'];
   /**
    * Determines if an open element can be closed by clicking on it.
    * Only applicable to the `single` variants.

--- a/src/components/Accordion/utils.ts
+++ b/src/components/Accordion/utils.ts
@@ -1,21 +1,30 @@
 import classnames from 'classnames';
-import { AccordionType, AccordionVariantKey, AccordionVariantProps, AccordionVariants } from './types';
+import { AccordionVariantKey, AccordionVariants } from './types';
+import { AccordionMultipleProps, AccordionSingleProps } from '@radix-ui/react-accordion';
 
 /**
  * Sets the type and collapsible props based on the variant prop
  * The collapsible prop should only be passed when the variant is single
  */
-export const getAccordionVariantProps = (variant?: AccordionVariantKey): AccordionVariantProps => {
-  const variantProps: AccordionVariantProps = { type: AccordionType.multiple };
+export const getAccordionVariantProps = (
+  variant?: AccordionVariantKey,
+  value?: string[] | string,
+): AccordionSingleProps | AccordionMultipleProps => {
+  const variantProps: AccordionMultipleProps | AccordionSingleProps = { type: 'multiple' };
+
+  if (
+    (variant === AccordionVariants.singleCollapsible || variant === AccordionVariants.singleNonCollapsible) &&
+    Array.isArray(value)
+  ) {
+    console.error('The value prop should not be an array when using a single variant');
+  }
 
   if (variant === AccordionVariants.singleCollapsible) {
-    variantProps.type = AccordionType.single;
-    variantProps.collapsible = true;
+    return { type: 'single' };
   }
 
   if (variant === AccordionVariants.singleNonCollapsible) {
-    variantProps.type = AccordionType.single;
-    variantProps.collapsible = false;
+    return { type: 'single' };
   }
 
   return variantProps;

--- a/src/components/Input/_input.scss
+++ b/src/components/Input/_input.scss
@@ -23,6 +23,10 @@ $lg: #{$px}-input--lg;
     &--hidden {
       @include hidden;
     }
+
+    @media (min-width: $breakpoint-md) {
+      font-size: 1rem;
+    }
   }
 
   &__input {
@@ -47,7 +51,7 @@ $lg: #{$px}-input--lg;
     -webkit-box-orient: vertical;
     display: -webkit-box;
     -webkit-line-clamp: 2;
-    line-height: 1.25;
+    line-height: $spacing-md;
     overflow: hidden;
   }
 

--- a/src/components/Input/_input.scss
+++ b/src/components/Input/_input.scss
@@ -14,18 +14,15 @@ $lg: #{$px}-input--lg;
   }
 
   &__label {
+    @include text($string2);
+
     color: $pure-black;
-    font-size: 0.75rem;
     font-variation-settings: 'wght' 600;
     margin-bottom: 0.5rem;
     word-break: break-word;
 
     &--hidden {
       @include hidden;
-    }
-
-    @media (min-width: $breakpoint-md) {
-      font-size: 1rem;
     }
   }
 


### PR DESCRIPTION
…make accordion controllable

**Jira ticket**

[L3-3327](https://phillipsauctions.atlassian.net/browse/L3-3327)

**Summary**

Make labels for inputs 16px on larger breakpoints than mobile
Make accordion controllable

consumed by https://github.com/PhillipsAuctionHouse/phillips-public-remix/pull/444

**Change List (describe the changes made to the files)**

- Additions, Changes, and Removals

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-3327]: https://phillipsauctions.atlassian.net/browse/L3-3327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ