### PR TITLE
fix(objecttile): L3-4346 - ensure objecttile content is left aligned

### DIFF
--- a/src/patterns/ObjectTile/_objectTile.scss
+++ b/src/patterns/ObjectTile/_objectTile.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   max-width: 24.5rem;
+  text-align: left;
 
   &__img {
     margin-bottom: $spacing-sm;


### PR DESCRIPTION
**Jira ticket**

[L3-4346](https://phillipsauctions.atlassian.net/browse/L3-4346)



**Summary**

Ensuring that the object tile content is left align regardless of parent styles

**Change List (describe the changes made to the files)**

- added text alignment to object tile



<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
