### PR TITLE
fix(seldonimage): L3-4753 memoize image component, pass srcset and si…

### DIFF
--- a/src/components/SeldonImage/SeldonImage.stories.tsx
+++ b/src/components/SeldonImage/SeldonImage.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/react';
-import SeldonImage, { SeldonImageProps } from './SeldonImage';
+import SeldonImage from './SeldonImage';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 const meta = {
@@ -8,7 +8,7 @@ const meta = {
 } satisfies Meta<typeof SeldonImage>;
 
 export default meta;
-export const Playground = (props: SeldonImageProps) => <SeldonImage {...props} />;
+export const Playground = (props: React.ComponentProps<typeof SeldonImage>) => <SeldonImage {...props} />;
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 Playground.args = {
@@ -18,7 +18,7 @@ Playground.args = {
 
 Playground.argTypes = {};
 
-export const CircleImage = (props: SeldonImageProps) => <SeldonImage {...props} />;
+export const CircleImage = (props: React.ComponentProps<typeof SeldonImage>) => <SeldonImage {...props} />;
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 CircleImage.args = {
@@ -32,7 +32,7 @@ CircleImage.args = {
 
 CircleImage.argTypes = {};
 
-export const BlurBackground = (props: SeldonImageProps) => <SeldonImage {...props} />;
+export const BlurBackground = (props: React.ComponentProps<typeof SeldonImage>) => <SeldonImage {...props} />;
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 BlurBackground.args = {
@@ -44,7 +44,7 @@ BlurBackground.args = {
 
 BlurBackground.argTypes = {};
 
-export const BrokenImage = (props: SeldonImageProps) => <SeldonImage {...props} />;
+export const BrokenImage = (props: React.ComponentProps<typeof SeldonImage>) => <SeldonImage {...props} />;
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 BrokenImage.args = {

--- a/src/components/SeldonImage/SeldonImage.tsx
+++ b/src/components/SeldonImage/SeldonImage.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, forwardRef, useRef, useState, useEffect, useCallback } from 'react';
+import { ComponentProps, forwardRef, useRef, useState, useEffect, useCallback, memo } from 'react';
 import classnames from 'classnames';
 
 import { getCommonProps } from '../../utils';
@@ -23,6 +23,14 @@ export interface SeldonImageProps extends ComponentProps<'div'> {
    * The image to display.
    */
   src: string;
+  /**
+   * The srcset of the image [https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset]
+   */
+  srcSet?: string;
+  /**
+   * The sizes of the image [https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes]
+   */
+  sizes?: string;
   /**
    * The alt text of the image.
    */
@@ -61,85 +69,91 @@ function isImageValid(src: string) {
  *
  * [Storybook Link](https://phillips-seldon.netlify.app/?path=/docs/components-seldonimage--overview)
  */
-const SeldonImage = forwardRef<HTMLDivElement, SeldonImageProps>(
-  (
-    {
-      className,
-      aspectRatio = 'none',
-      objectFit = 'none',
-      hasBlurBackground = false,
-      imageClassName,
-      imageStyle,
-      src,
-      alt,
-      errorText = 'Error loading image',
-      ...props
-    },
-    ref,
-  ) => {
-    const { className: baseClassName, ...commonProps } = getCommonProps(props, 'SeldonImage');
-    const imgRef = useRef<HTMLImageElement>(null);
+const SeldonImage = memo(
+  forwardRef<HTMLDivElement, SeldonImageProps>(
+    (
+      {
+        className,
+        aspectRatio = 'none',
+        objectFit = 'none',
+        hasBlurBackground = false,
+        imageClassName,
+        imageStyle,
+        src,
+        alt,
+        srcSet,
+        sizes,
+        errorText = 'Error loading image',
+        ...props
+      },
+      ref,
+    ) => {
+      const { className: baseClassName, ...commonProps } = getCommonProps(props, 'SeldonImage');
+      const imgRef = useRef<HTMLImageElement>(null);
 
-    const [loadingState, setLoadingState] = useState<'loading' | 'loaded' | 'error'>('loading');
+      const [loadingState, setLoadingState] = useState<'loading' | 'loaded' | 'error'>('loading');
 
-    const loadImage = useCallback(async () => {
-      const isValid = await isImageValid(src);
-      if (!isValid) {
-        setLoadingState('error');
-      } else {
-        setLoadingState('loaded');
-      }
-    }, [src]);
+      const loadImage = useCallback(async () => {
+        const isValid = await isImageValid(src);
+        if (!isValid) {
+          setLoadingState('error');
+        } else {
+          setLoadingState('loaded');
+        }
+      }, [src]);
 
-    useEffect(() => {
-      void loadImage();
-    }, [loadImage]);
+      useEffect(() => {
+        void loadImage();
+      }, [loadImage]);
 
-    return (
-      <div
-        ref={ref}
-        className={classnames(baseClassName, className, {
-          [`${baseClassName}--hidden`]: loadingState === 'loading' || loadingState === 'error',
-          [`${baseClassName}--aspect-ratio-${aspectRatio.replace('/', '-')}`]: aspectRatio !== 'none',
-        })}
-        role="img"
-        aria-label={alt}
-        {...props}
-        {...commonProps}
-      >
-        {hasBlurBackground && (
-          <div
-            className={classnames(`${baseClassName}-blur`, {
-              [`${baseClassName}-blur--hidden`]: loadingState === 'loading' || loadingState === 'error',
-            })}
-            style={{ backgroundImage: `url(${src})` }}
-          />
-        )}
-        {loadingState === 'error' ? (
-          <div className={`${baseClassName}--error`}>
-            <PhillipsLogo aria-label={errorText} />
-          </div>
-        ) : null}
-        <img
-          className={classnames(`${baseClassName}-img`, imageClassName, {
-            [`${baseClassName}-img--hidden`]: loadingState !== 'loaded',
-            [`${baseClassName}-img--object-fit-${objectFit}`]: objectFit !== 'none',
+      return (
+        <div
+          ref={ref}
+          className={classnames(baseClassName, className, {
+            [`${baseClassName}--hidden`]: loadingState === 'loading' || loadingState === 'error',
+            [`${baseClassName}--aspect-ratio-${aspectRatio.replace('/', '-')}`]: aspectRatio !== 'none',
           })}
-          style={imageStyle}
-          src={src}
-          alt={alt}
-          data-testid={`${commonProps['data-testid']}-img`}
-          ref={imgRef}
-          onLoad={() => {
-            setLoadingState('loaded');
-          }}
-          onError={() => {
-            setLoadingState('error');
-          }}
-        />
-      </div>
-    );
-  },
+          role="img"
+          aria-label={alt}
+          {...props}
+          {...commonProps}
+        >
+          {hasBlurBackground && (
+            <div
+              className={classnames(`${baseClassName}-blur`, {
+                [`${baseClassName}-blur--hidden`]: loadingState === 'loading' || loadingState === 'error',
+              })}
+              style={{ backgroundImage: `url(${src})` }}
+            />
+          )}
+          {loadingState === 'error' ? (
+            <div className={`${baseClassName}--error`}>
+              <PhillipsLogo aria-label={errorText} />
+            </div>
+          ) : null}
+          <img
+            className={classnames(`${baseClassName}-img`, imageClassName, {
+              [`${baseClassName}-img--hidden`]: loadingState !== 'loaded',
+              [`${baseClassName}-img--object-fit-${objectFit}`]: objectFit !== 'none',
+            })}
+            style={imageStyle}
+            src={src}
+            srcSet={srcSet}
+            sizes={sizes}
+            alt={alt}
+            data-testid={`${commonProps['data-testid']}-img`}
+            ref={imgRef}
+            onLoad={() => {
+              setLoadingState('loaded');
+            }}
+            onError={() => {
+              setLoadingState('error');
+            }}
+          />
+        </div>
+      );
+    },
+  ),
 );
 
 SeldonImage.displayName = 'SeldonImage';


### PR DESCRIPTION
…zes to image

**Jira ticket**

[L3-4753](https://phillipsauctions.atlassian.net/browse/L3-4753)

**Summary**

Memoize the image, pass in srcset and sizes to image for future potential optimizations

**Change List (describe the changes made to the files)**

- Wrap seldon image in react.memo, pass in srcset and sizes property

**Acceptance Test (how to verify the PR)**

- Image still works

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-4753]: https://phillipsauctions.atlassian.net/browse/L3-4753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ