### PR TITLE
fix(tabpanel): L3-4919 tab component was hiding the tabpanel role from screen readers

### DIFF
--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -27,6 +27,8 @@ describe('Tabs', () => {
 
     // Verify default tab content is visible
     expect(screen.getByText('Overview content')).toBeVisible();
+    expect(screen.getByRole('tabpanel', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.queryByRole('tabpanel', { name: 'Browse lots' })).not.toBeInTheDocument();
   });
   test('renders ReactNode in tab', () => {
     const componentTabs = [
@@ -66,6 +68,8 @@ describe('Tabs', () => {
     await userEvent.click(screen.getByRole('tab', { name: /Browse/i }));
 
     expect(screen.getByText('Browse lots content')).toBeVisible();
+    expect(screen.getByRole('tabpanel', { name: 'Browse lots' })).toBeInTheDocument();
+    expect(screen.queryByRole('tabpanel', { name: 'Overview' })).not.toBeInTheDocument();
   });
   test('calls onTabClick when a tab is clicked', async () => {
     const onTabClickMock = vitest.fn();

--- a/src/components/Tabs/TabsContent.tsx
+++ b/src/components/Tabs/TabsContent.tsx
@@ -36,7 +36,6 @@ const TabsContent = forwardRef<HTMLDivElement, TabContentProps>(
         {...commonProps}
         ref={ref}
         tabIndex={-1}
-        aria-hidden
       >
         {children}
       </TabsPrimitive.Content>


### PR DESCRIPTION
**Jira ticket**

[L3-4919](https://phillipsauctions.atlassian.net/browse/L3-4919)

**Summary**

Because the `aria-hidden` property was set on the `<TabContent` panel, screen readers were not being notified that the content being shown to the user was within a "tabpanel" role.

**Change List (describe the changes made to the files)**

- change(TabsContent): remove aria-hidden
- change(Tabs.test): add test assertions to check for the tabpanel roles

**Acceptance Test (how to verify the PR)**

- If the testcases pass it's working since they verify accessibility now

**Regression Test**

- Verify the keyboard navigability of the Tab story still functions

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-4919]: https://phillipsauctions.atlassian.net/browse/L3-4919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ