### PR TITLE
fix(textsymbol): L3-5094 normalize symbol size

### DIFF
--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -26,7 +26,7 @@ describe('Text', () => {
     renderText({
       children: (
         <>
-          Hello World<TextSymbol variant={TextSymbolVariants.lotNumber}>sup</TextSymbol>
+          Hello World<TextSymbol variant={TextSymbolVariants.lotNumber} symbols={['sup']}></TextSymbol>
         </>
       ),
     });

--- a/src/components/TextSymbol/TextSymbol.stories.tsx
+++ b/src/components/TextSymbol/TextSymbol.stories.tsx
@@ -17,10 +17,7 @@ export const Playground = (props: TextSymbolProps) => (
   </Text>
 );
 
-Playground.args = {
-  children: 'ЖΟ◆',
-  variant: TextSymbolVariants.lotNumber,
-};
+Playground.args = { symbols: 'Ο‡≠♠ΩΔ•†◆Σ܀∞✱▼Ж≌Ø'.split(''), variant: TextSymbolVariants.lotNumber };
 
 Playground.argTypes = {
   variant: {

--- a/src/components/TextSymbol/TextSymbol.test.tsx
+++ b/src/components/TextSymbol/TextSymbol.test.tsx
@@ -4,6 +4,8 @@ import TextSymbol, { TextSymbolProps } from './TextSymbol';
 import { px } from '../../utils';
 import { TextSymbolVariants } from './types';
 
+const symbols = 'Ο‡≠♠ΩΔ•†◆Σ܀∞✱▼Ж≌Ø'.split('');
+
 describe('TextSymbol', () => {
   runCommonTests(TextSymbol, 'TextSymbol');
   const renderTextSymbol = (props: TextSymbolProps) => {
@@ -11,20 +13,25 @@ describe('TextSymbol', () => {
   };
 
   it('renders children correctly', () => {
-    renderTextSymbol({ children: 'Hello World' });
-
-    expect(screen.getByText('Hello World')).toBeInTheDocument();
+    renderTextSymbol({ symbols });
+    symbols.forEach((symbol) => expect(screen.getByText(symbol)).toBeInTheDocument());
   });
 
   it('applies the default variant correctly', () => {
-    renderTextSymbol({ children: 'Default Variant' });
-
-    expect(screen.getByText('Default Variant')).toHaveClass(`${px}-text-symbol--lotNumber`);
+    renderTextSymbol({ symbols });
+    expect(screen.getByTestId('text-symbol')).toHaveClass(`${px}-text-symbol--lotNumber`);
   });
 
   it('applies the estimation variant correctly', () => {
-    renderTextSymbol({ children: 'Estimation Variant', variant: TextSymbolVariants.estimation });
-
-    expect(screen.getByText('Estimation Variant')).toHaveClass(`${px}-text-symbol--estimation`);
+    renderTextSymbol({ symbols, variant: TextSymbolVariants.estimation });
+    expect(screen.getByTestId('text-symbol')).toHaveClass(`${px}-text-symbol--estimation`);
+  });
+  it('applies symbol size correctly', () => {
+    const largeSymbols = 'Ο‡'.split('');
+    renderTextSymbol({ symbols: largeSymbols });
+    largeSymbols.forEach((symbol) => {
+      const symbolElement = screen.getByText(symbol);
+      expect(symbolElement).toHaveClass(`${px}-text-symbol--large-symbol`);
+    });
   });
 });

--- a/src/components/TextSymbol/TextSymbol.tsx
+++ b/src/components/TextSymbol/TextSymbol.tsx
@@ -1,20 +1,29 @@
 import classNames from 'classnames';
 import { getCommonProps } from '../../utils';
 import { TextSymbolVariants } from './types';
+import { determineSymbolSize } from './utils';
 
 export interface TextSymbolProps extends React.HTMLAttributes<HTMLElement> {
   /**
-   * The varian of the text symbol which will determine the position and spacing
+   * An array of string symbols to show
+   */
+  symbols?: string[];
+  /**
+   * The variant of the text symbol which will determine the position and spacing
    */
   variant?: TextSymbolVariants;
 }
 
-const TextSymbol = ({ children, variant = TextSymbolVariants.lotNumber, className, ...props }: TextSymbolProps) => {
+const TextSymbol = ({ symbols = [], variant = TextSymbolVariants.lotNumber, className, ...props }: TextSymbolProps) => {
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'TextSymbol');
 
   return (
     <span {...commonProps} className={classNames(baseClassName, className, `${baseClassName}--${variant}`)} {...props}>
-      {children}
+      {symbols.map((symbol, index) => (
+        <span key={index} className={`${baseClassName}--${determineSymbolSize(symbol)}-symbol`}>
+          {symbol}
+        </span>
+      ))}
     </span>
   );
 };

--- a/src/components/TextSymbol/_textSymbol.scss
+++ b/src/components/TextSymbol/_textSymbol.scss
@@ -8,8 +8,19 @@
   }
 
   &--lotNumber {
-    font-size: 65%;
     margin-left: $spacing-xsm;
     vertical-align: super;
+  }
+
+  &--large-symbol {
+    font-size: 65%;
+  }
+
+  &--medium-symbol {
+    font-size: 85%;
+  }
+
+  &--small-symbol {
+    font-size: 100%;
   }
 }

--- a/src/components/TextSymbol/types.ts
+++ b/src/components/TextSymbol/types.ts
@@ -2,3 +2,9 @@ export enum TextSymbolVariants {
   estimation = 'estimation',
   lotNumber = 'lotNumber',
 }
+
+export enum TextSymbolSize {
+  small = 'small',
+  medium = 'medium',
+  large = 'large',
+}

--- a/src/components/TextSymbol/utils.test.ts
+++ b/src/components/TextSymbol/utils.test.ts
@@ -1,0 +1,33 @@
+import { TextSymbolSize } from './types';
+import { determineSymbolSize } from './utils';
+
+describe('determineSymbolSize', () => {
+  it('should return small size for small symbols', () => {
+    const smallSymbols = ['≌', '܀', '•'];
+    smallSymbols.forEach((symbol) => {
+      const size = determineSymbolSize(symbol);
+      expect(size).toBe(TextSymbolSize.small);
+    });
+  });
+
+  it('should return medium size for medium symbols', () => {
+    const mediumSymbols = ['▼', '♠', '≠'];
+    mediumSymbols.forEach((symbol) => {
+      const size = determineSymbolSize(symbol);
+      expect(size).toBe(TextSymbolSize.medium);
+    });
+  });
+
+  it('should return large size for large symbols', () => {
+    const largeSymbols = ['∞', 'Ω', 'Δ', '†', '◆', 'Σ', '✱', 'Ж', 'Ο', '‡', 'Ø'];
+    largeSymbols.forEach((symbol) => {
+      const size = determineSymbolSize(symbol);
+      expect(size).toBe(TextSymbolSize.large);
+    });
+  });
+
+  it('should return large size for unknown symbols', () => {
+    const size = determineSymbolSize('unknown');
+    expect(size).toBe(TextSymbolSize.large);
+  });
+});

--- a/src/components/TextSymbol/utils.ts
+++ b/src/components/TextSymbol/utils.ts
@@ -1,0 +1,27 @@
+import { TextSymbolSize } from './types';
+
+export const determineSymbolSize = (symbol: string) => {
+  switch (symbol) {
+    case '≌':
+    case '܀':
+    case '•':
+      return TextSymbolSize.small;
+    case '▼':
+    case '♠':
+    case '≠':
+      return TextSymbolSize.medium;
+    case '∞':
+    case 'Ω':
+    case 'Δ':
+    case '†':
+    case '◆':
+    case 'Σ':
+    case '✱':
+    case 'Ж':
+    case 'Ο':
+    case '‡':
+    case 'Ø':
+    default:
+      return TextSymbolSize.large;
+  }
+};


### PR DESCRIPTION
**Jira ticket**

[L3-5094](https://phillipsauctions.atlassian.net/browse/L3-5094)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/9daef98f-9a3a-49fd-bc61-89d36749096d) | ![image](https://github.com/user-attachments/assets/926e05b4-ca66-4a49-9390-11241ee5e944) |

**Summary**

Some of the symbols we support are way too small in our font, this fix tries to normalize their size better so they're readable

**Change List (describe the changes made to the files)**

- change(TextSymbol): switch `children` prop to `symbols` array since I have to examine each one and adjust its size
- change(_textSymbol.scss): add 3 size classes
- change(utils.ts): helper function to figure out which symbol is which size.

**Acceptance Test (how to verify the PR)**

- Check the text symbol story

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-5094]: https://phillipsauctions.atlassian.net/browse/L3-5094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ