### PR TITLE
fix(tabs): L3-4707 Remove Focus Border From Tabs on Click

### DIFF
--- a/src/components/Tabs/TabTrigger.tsx
+++ b/src/components/Tabs/TabTrigger.tsx
@@ -32,7 +32,6 @@ const TabTrigger = forwardRef<HTMLButtonElement, TabTriggerProps>(({ value, onCl
       value={value}
       className={`${baseClassName}__tabs-trigger`}
       onClick={() => onClick?.(value)}
-      tabIndex={0}
       ref={ref}
     >
       {children}

--- a/src/components/Tabs/TabTrigger.tsx
+++ b/src/components/Tabs/TabTrigger.tsx
@@ -32,6 +32,7 @@ const TabTrigger = forwardRef<HTMLButtonElement, TabTriggerProps>(({ value, onCl
       value={value}
       className={`${baseClassName}__tabs-trigger`}
       onClick={() => onClick?.(value)}
+      tabIndex={0}
       ref={ref}
     >
       {children}

--- a/src/components/Tabs/_tabs.scss
+++ b/src/components/Tabs/_tabs.scss
@@ -17,7 +17,7 @@
     background: none;
     border: none;
     border-bottom: 2px solid transparent;
-    padding: 0 0 $padding-sm;
+    padding: $padding-xsm $padding-xsm $padding-sm;
     transition:
       background 0.2s ease,
       font-weight 0.2s ease-out,


### PR DESCRIPTION
**Jira ticket**

[L3-4707](https://phillipsauctions.atlassian.net/browse/L3-4707)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![ea2f0ca4-68b3-4650-bfc9-4cf56f89a6db](https://github.com/user-attachments/assets/65ab9aaf-1e95-472f-be8d-37aab1cc95b1)| ![Screenshot 2025-01-23 121134](https://github.com/user-attachments/assets/223a7a42-cf9a-41b5-a10c-0115e8b4532a) |

**Summary**

 Fixed tabbing functionality and corrected focus styles

**Change List (describe the changes made to the files)**

- Adjusted padding for tab content
- Added tabIndex to TabTrigger component

**Acceptance Test (how to verify the PR)**

- Verify that outline only shows when tabbing through tabs and not on click of the tab

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-4707]: https://phillipsauctions.atlassian.net/browse/L3-4707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ