### PR TITLE
fix(link): L3-5135 Fix Underline Spacing For Links

### DIFF
--- a/src/scss/_type.scss
+++ b/src/scss/_type.scss
@@ -37,7 +37,7 @@
   font-family: Distinct, sans-serif;
 }
 
-@mixin underline($offset: $spacing-xsm, $thickness: 1px, $color: $pure-black) {
+@mixin underline($offset: $spacing-micro, $thickness: 1px, $color: $pure-black) {
   text-decoration: underline;
   text-decoration-thickness: $thickness;
   text-underline-offset: $offset;


### PR DESCRIPTION
**Jira ticket**

[L3-5135](https://phillipsauctions.atlassian.net/browse/L3-5135)

**Screenshots**
| Before | After |
| ----- | ----- |
| ![ab7c679c-087b-4aee-ad02-f5fb7e4ac96a](https://github.com/user-attachments/assets/5f507e50-5f0c-4a89-8f7e-0fd9f8bc1092) | ![Screenshot 2025-01-29 112719](https://github.com/user-attachments/assets/cb0fc5a4-aa0b-43df-a2e8-e8cba496f9c0) |

**Summary**

Adjusted the underline offset for links

**Change List (describe the changes made to the files)**

This pull request includes a minor change to the `src/scss/_type.scss` file. The change updates the `underline` mixin to use a different spacing variable for the offset parameter.

Styling adjustment:

* [`src/scss/_type.scss`](diffhunk://#diff-2ee3e65f8a2cdd6cdfa290d38c5157311252d6888567ba85a750232523fb42fbL40-R40): Modified the `underline` mixin to use `$spacing-micro` instead of `$spacing-xsm` for the offset parameter.

**Acceptance Test (how to verify the PR)**

- Verify that links now use the `$spacing-micro` value for text-underline-offset. 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-5135]: https://phillipsauctions.atlassian.net/browse/L3-5135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ