### PR TITLE
fix(bidsnapshot): L3-5370 sold price should still show text if sold price is hidden

### DIFF
--- a/src/patterns/BidSnapshot/BidSnapshot.stories.tsx
+++ b/src/patterns/BidSnapshot/BidSnapshot.stories.tsx
@@ -18,22 +18,25 @@ const meta = {
 
 export default meta;
 export const Playground = (props: BidSnapshotProps) => {
-  const { bidStatus, lotStatus, lotCloseDate, currentBid, ...rest } = props;
+  const { bidStatus, lotStatus, lotCloseDate, currentBid, soldPrice, soldForText, wonForText, ...rest } = props;
+  const soldForLabel = !soldPrice ? 'Sold' : soldForText;
+  const wonForLabel = !soldPrice ? 'Won' : wonForText;
+
   return (
     <BidSnapshot
       bidStatus={bidStatus}
       lotStatus={lotStatus}
       currentBid={currentBid}
       lotCloseDate={lotStatus === LotStatus.ready ? undefined : lotCloseDate}
+      soldPrice={soldPrice}
+      soldForText={soldForLabel}
+      wonForText={wonForLabel}
       {...rest}
     >
       {bidStatus === BidStatusEnum.Winning ? <BidMessage message="With You" /> : null}
       {bidStatus === BidStatusEnum.Won ? <BidMessage message="Won bid" /> : null}
       {bidStatus === BidStatusEnum.Losing ? (
         <BidMessage variant={BidMessageVariants.negative} message="Losing Bid" />
-      ) : null}
-      {bidStatus === BidStatusEnum.Lost ? (
-        <BidMessage variant={BidMessageVariants.negative} message="Lost Bid" />
       ) : null}
     </BidSnapshot>
   );
@@ -54,5 +57,5 @@ Playground.args = {
 
 Playground.argTypes = {
   bidStatus: { options: BidStatusEnum, control: { type: 'select' } },
-  auctionStatus: { options: LotStatus, control: { type: 'select' } },
+  lotStatus: { options: LotStatus, control: { type: 'select' } },
 };

--- a/src/patterns/BidSnapshot/BidSnapshot.test.tsx
+++ b/src/patterns/BidSnapshot/BidSnapshot.test.tsx
@@ -65,7 +65,7 @@ describe('BidSnapshot', () => {
     expect(screen.queryByText('You won')).not.toBeInTheDocument();
   });
 
-  it('renders won for instead of sold for when auction is past user lost', () => {
+  it('renders sold for when auction is past and user lost', () => {
     render(
       <BidSnapshot
         startingBid={100}
@@ -78,7 +78,7 @@ describe('BidSnapshot', () => {
         <BidMessage message="You lost"></BidMessage>
       </BidSnapshot>,
     );
-    expect(screen.getByText('Won for')).toBeInTheDocument();
+    expect(screen.getByText('Sold for')).toBeInTheDocument();
     expect(screen.getByText('$300')).toBeInTheDocument();
     expect(screen.getByText('You lost')).toBeInTheDocument();
   });
@@ -99,7 +99,25 @@ describe('BidSnapshot', () => {
     expect(screen.getByText('$300')).toBeInTheDocument();
   });
 
-  it('does not render sold for if soldPrice not passed, used if auction should hide sold price', () => {
+  it('does not render soldPrice if not passed, user won', () => {
+    render(
+      <BidSnapshot
+        startingBid={100}
+        currentBid={500}
+        numberOfBids={3}
+        lotStatus={LotStatus.past}
+        bidStatus={BidStatusEnum.Won}
+        wonForText="Won"
+      >
+        <BidMessage message="You won" />
+      </BidSnapshot>,
+    );
+    expect(screen.getByText('Won')).toBeInTheDocument();
+    expect(screen.queryByText('$500')).not.toBeInTheDocument();
+    expect(screen.getByText('You won')).toBeInTheDocument();
+  });
+
+  it('does not render soldPrice if not passed, user lost', () => {
     render(
       <BidSnapshot
         startingBid={100}
@@ -107,13 +125,14 @@ describe('BidSnapshot', () => {
         numberOfBids={3}
         lotStatus={LotStatus.past}
         bidStatus={BidStatusEnum.Lost}
+        soldForText="Sold"
       >
-        <BidMessage message="You won" />
+        <BidMessage message="You lost" />
       </BidSnapshot>,
     );
-    expect(screen.queryByText('Sold for')).not.toBeInTheDocument();
+    expect(screen.getByText('Sold')).toBeInTheDocument();
     expect(screen.queryByText('$500')).not.toBeInTheDocument();
-    expect(screen.getByText('You won')).toBeInTheDocument();
+    expect(screen.getByText('You lost')).toBeInTheDocument();
   });
 
   describe('countdown timer', () => {

--- a/src/patterns/BidSnapshot/BidSnapshot.tsx
+++ b/src/patterns/BidSnapshot/BidSnapshot.tsx
@@ -143,10 +143,10 @@ const BidSnapshot = forwardRef<HTMLDivElement, BidSnapshotProps>(
     return (
       <div {...commonProps} {...props} ref={ref} className={classes}>
         <DetailList hasSeparators className={`${baseClassName}__text`}>
-          {isPast && hasBids && soldPrice ? (
+          {isPast && hasBids ? (
             <Detail
-              label={bidStatus ? wonForText : soldForText} // if the user has bid show wonForText else show soldForText
-              value={`${currency}${soldPrice?.toLocaleString()}`}
+              label={bidStatus === BidStatusEnum.Won ? wonForText : soldForText} // if the user has won show wonForText else show soldForText
+              value={soldPrice ? `${currency}${soldPrice?.toLocaleString()}` : ''}
               hasWrap={false}
             />
           ) : null}


### PR DESCRIPTION
**Jira ticket**

[L3-5370](https://phillipsauctions.atlassian.net/browse/L3-5370)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/00e159d4-c209-4844-81bc-5412d4bf7b9c) | ![image](https://github.com/user-attachments/assets/cd550aa7-8998-49e3-a635-2a05db09dd8f) 

**Summary**

If soldPrice is 0, but bids have occurred, we should be showing the `soldForText` and `wonForText` but hiding the sold price (i.e. soldPrice=0).  Previously we were hiding the whole sold section

**Change List (describe the changes made to the files)**

Refinements in rendering logic:

* [`src/patterns/BidSnapshot/BidSnapshot.tsx`](diffhunk://#diff-023608454dd8a373f83e678913fe1db898600977d93505f7afa1ff759b3c3e59L146-R149): Change the rendering logic in the `BidSnapshot` component to continue to show the "soldForText" and "wonForText" if the soldPrice is 0..

**Acceptance Test (how to verify the PR)**

- Start the BidSnapshot story
- Set LotStatus to Past, and sold Price to 0
- Verify the lot shows "Sold"
- Now switch bidstatus to "Won"
- Verify the lot shows "Won"

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-5370]: https://phillipsauctions.atlassian.net/browse/L3-5370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ