### PR TITLE
fix(input): L3-5289 improve styling for readonly inputs

### DIFF
--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -110,6 +110,13 @@ describe('An Input', () => {
     await waitFor(() => expect(mockedOnClick.mock.calls).toHaveLength(1));
   });
 
+  it('will change the input value', async () => {
+    render(<Input {...reqProps} />);
+    await userEvent.click(screen.getByTestId('test-id'));
+    await userEvent.keyboard('s');
+    expect(screen.getByTestId('test-id')).toHaveValue('s');
+  });
+
   it('will not fire the onClick handler when disabled', async () => {
     const mockedOnClick = vi.fn();
     render(<Input {...reqProps} onClick={mockedOnClick} disabled />);
@@ -119,7 +126,8 @@ describe('An Input', () => {
 
   it('will not change the input when readOnly', async () => {
     render(<Input {...reqProps} readOnly />);
-    await userEvent.type(screen.getByTestId('test-id'), 's');
+    await userEvent.click(screen.getByTestId('test-id'));
+    await userEvent.keyboard('s');
     expect(screen.getByTestId('test-id')).not.toHaveValue('s');
   });
 });

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -109,4 +109,17 @@ describe('An Input', () => {
     await userEvent.click(screen.getByTestId('test-id'));
     await waitFor(() => expect(mockedOnClick.mock.calls).toHaveLength(1));
   });
+
+  it('will not fire the onClick handler when disabled', async () => {
+    const mockedOnClick = vi.fn();
+    render(<Input {...reqProps} onClick={mockedOnClick} disabled />);
+    await userEvent.click(screen.getByTestId('test-id'));
+    expect(mockedOnClick).not.toHaveBeenCalled();
+  });
+
+  it('will not change the input when readOnly', async () => {
+    render(<Input {...reqProps} readOnly />);
+    await userEvent.type(screen.getByTestId('test-id'), 's');
+    expect(screen.getByTestId('test-id')).not.toHaveValue('s');
+  });
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -15,7 +15,9 @@ export interface InputProps extends Omit<React.ComponentProps<'input'>, 'size'> 
   defaultValue?: string | number | readonly string[];
 
   /**
-   * Booolean to specify whether the `<input>` should be disabled
+   * Boolean to specify whether the `<input>` should be disabled.
+   * WARNING: disabled field values will NOT be submitted when a form is submitted according to the HTML spec.
+   * Instead use `readOnly` to prevent user input but still submit the value.
    */
   disabled?: boolean;
 

--- a/src/components/Input/_input.scss
+++ b/src/components/Input/_input.scss
@@ -66,7 +66,8 @@ $lg: #{$px}-input--lg;
   }
 
   // Disabled
-  &--disabled {
+  &--disabled,
+  &--readonly {
     color: $keyline-gray;
     cursor: default;
 
@@ -78,19 +79,10 @@ $lg: #{$px}-input--lg;
     .#{$px}-input__input:hover {
       cursor: default;
     }
-  }
-
-  // Read only
-  &--readonly {
-    pointer-events: none;
-
-    .#{$px}-input__label,
-    .#{$px}-input__input {
-      cursor: default;
-    }
 
     .#{$px}-input__input {
       background-color: rgba(239, 239, 239, 30%);
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
**Jira ticket**

[L3-5289](https://phillipsauctions.atlassian.net/browse/L3-5289)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/0c132ae7-0172-453c-b583-4023189bbec0) | ![image](https://github.com/user-attachments/assets/0ec5cdfd-f80d-431f-99af-098d2e1a26a8) |



**Summary**

The styles of our disabled and readOnly inputs did not match.  This brings them in line per design guidance [here](https://phillipsauction.slack.com/archives/C05U1JKR332/p1739911027363449).


**Change List (describe the changes made to the files)**

This pull request includes several changes to the `Input` component and its associated files to improve its functionality and styling. The most important changes include adding new tests, updating the `InputProps` interface, and modifying the SCSS styles for disabled and read-only states.

### Functional improvements:
* [`src/components/Input/Input.test.tsx`](diffhunk://#diff-f4f9d4b289e939dead1a68078f706095bfcf951f347a3163e3180337f931a0dcR112-R124): Added tests to ensure the `onClick` handler is not fired when the input is disabled and to verify that the input value does not change when it is read-only.

* [`src/components/Input/Input.tsx`](diffhunk://#diff-0414a1d786fc54ea337f45079b8c5d47254051dfc247a8f39d0f4c474fcb9f12L18-R20): Updated the `InputProps` interface to include a warning in the documentation for the `disabled` property, advising the use of `readOnly` to prevent user input while still submitting the value.

### Styling improvements:
* [`src/components/Input/_input.scss`](diffhunk://#diff-0f70c5df92b8e4c1b32a594fe163af2fd46331ba6ddf906c0d0a9d3f44cb988fL69-R70): Consolidated styles for disabled and read-only states, ensuring consistent cursor behavior and preventing pointer events for read-only inputs. [[1]](diffhunk://#diff-0f70c5df92b8e4c1b32a594fe163af2fd46331ba6ddf906c0d0a9d3f44cb988fL69-R70) [[2]](diffhunk://#diff-0f70c5df92b8e4c1b32a594fe163af2fd46331ba6ddf906c0d0a9d3f44cb988fL81-R85)

**Acceptance Test (how to verify the PR)**

- verify the input stories disabled and readOnly components match styles

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-5289]: https://phillipsauctions.atlassian.net/browse/L3-5289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ