### PR TITLE
fix(useId): L3-5569 replace useId function with a third-party library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "react-modal": "^3.16.1",
         "react-transition-group": "^4.4.5",
         "react-zoom-pan-pinch": "^3.6.1",
-        "usehooks-ts": "^3.1.0"
+        "usehooks-ts": "^3.1.0",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.3",
@@ -5227,6 +5228,20 @@
       },
       "peerDependencies": {
         "storybook": "^8.5.0"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
@@ -21026,16 +21041,16 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "react-modal": "^3.16.1",
     "react-transition-group": "^4.4.5",
     "react-zoom-pan-pinch": "^3.6.1",
-    "usehooks-ts": "^3.1.0"
+    "usehooks-ts": "^3.1.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.3",

--- a/src/components/Carousel/CarouselDots.tsx
+++ b/src/components/Carousel/CarouselDots.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { EmblaCarouselType } from 'embla-carousel';
-import { ComponentProps, forwardRef, useCallback, useEffect, useState, useId, useRef, useMemo } from 'react';
+import { ComponentProps, forwardRef, useCallback, useEffect, useState, useRef, useMemo } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { useCarousel } from './utils';
 import { getCommonProps } from '../../utils';
 import { CarouselDot } from './CarouselDot';
@@ -36,7 +37,7 @@ const centerDotContainer = 11;
 const CarouselDots = forwardRef<HTMLDivElement, CarouselDotsProps>(
   ({ className, maxDots = 9, position = 'inline', numberOfSlides = 0, ...props }, ref) => {
     const { className: baseClassName, ...commonProps } = getCommonProps(props, 'CarouselDots');
-    const componentId = useId();
+    const componentId = uuidv4();
     const { api, onSlideChange } = useCarousel();
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [scrollSnaps, setScrollSnaps] = useState<number[]>(

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
+import { v4 as uuidv4 } from 'uuid';
 
 import { px, useNormalizedInputProps } from '../../utils';
 
@@ -136,7 +137,7 @@ const Input = React.forwardRef(
     }: InputProps,
     ref: React.ForwardedRef<HTMLInputElement>,
   ) => {
-    const generatedId = React.useId();
+    const generatedId = uuidv4();
     const inputProps = useNormalizedInputProps({
       disabled,
       id: id || generatedId,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { px, useNormalizedInputProps } from '../../utils';
 import { InputProps } from '../Input/Input';
 import { Merge } from 'type-fest';
+import { v4 as uuidv4 } from 'uuid';
 
 import { SelectVariants } from './types';
 import ChevronDownIcon from '../../assets/chevronDown.svg?react';
@@ -59,7 +60,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     ref,
   ) => {
     const type = 'select';
-    const generatedId = React.useId();
+    const generatedId = uuidv4();
     const inputProps = useNormalizedInputProps({
       disabled,
       id: id ?? generatedId,


### PR DESCRIPTION
**Jira ticket**

[L3-5569](https://phillipsauctions.atlassian.net/browse/L3-5569)


**Summary**

Removes use of the new `useId` function in React 18, and bring in a third-party library.

**Change List (describe the changes made to the files)**

This pull request introduces the `uuid` library to replace the `useId` hook for generating unique IDs across multiple components. The most important changes include updating dependencies in `package.json` and modifying several components to use `uuidv4` for ID generation.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L63-R64): Added `uuid` library as a dependency.

Component updates:

* [`src/components/Carousel/CarouselDots.tsx`](diffhunk://#diff-c5f308f41986c7c6bef156edf8646b9efa0173c83ab41afdd1bae6f7cd30bb7eL3-R4): Imported `uuidv4` from `uuid` and replaced `useId` with `uuidv4` for generating `componentId`. [[1]](diffhunk://#diff-c5f308f41986c7c6bef156edf8646b9efa0173c83ab41afdd1bae6f7cd30bb7eL3-R4) [[2]](diffhunk://#diff-c5f308f41986c7c6bef156edf8646b9efa0173c83ab41afdd1bae6f7cd30bb7eL39-R40)
* [`src/components/Input/Input.tsx`](diffhunk://#diff-0414a1d786fc54ea337f45079b8c5d47254051dfc247a8f39d0f4c474fcb9f12R3): Imported `uuidv4` from `uuid` and replaced `useId` with `uuidv4` for generating `generatedId`. [[1]](diffhunk://#diff-0414a1d786fc54ea337f45079b8c5d47254051dfc247a8f39d0f4c474fcb9f12R3) [[2]](diffhunk://#diff-0414a1d786fc54ea337f45079b8c5d47254051dfc247a8f39d0f4c474fcb9f12L139-R140)
* [`src/components/Select/Select.tsx`](diffhunk://#diff-d6181d40b4597b102e57c0daacdac25ca9f5082357c4360133812235abc7bee1R6): Imported `uuidv4` from `uuid` and replaced `useId` with `uuidv4` for generating `generatedId`. [[1]](diffhunk://#diff-d6181d40b4597b102e57c0daacdac25ca9f5082357c4360133812235abc7bee1R6) [[2]](diffhunk://#diff-d6181d40b4597b102e57c0daacdac25ca9f5082357c4360133812235abc7bee1L62-R63)

**Acceptance Test (how to verify the PR)**

- if testcases pass and phililips-public cn be upgraded we should be in good shpe.

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-5569]: https://phillipsauctions.atlassian.net/browse/L3-5569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ