### PR TITLE
fix(sale-header-banner): L3-5540 PLP Sale Header Banner Fixes

### DIFF
--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -7,14 +7,15 @@
   align-items: center;
   background-color: $pure-black;
   border: 1px solid transparent;
-  border-radius: 100px;
+  border-radius: 6.25rem;
   color: $pure-white;
   cursor: pointer;
   display: inline-flex;
   font-variation-settings: 'wght' 600;
   gap: $margin-xsm;
+  height: $spacing-lg;
   justify-content: center;
-  padding: $snw-button-padding $padding-md;
+  padding: 0 $padding-md;
   position: relative;
   transition:
     color 0.25s,

--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -13,9 +13,8 @@
   display: inline-flex;
   font-variation-settings: 'wght' 600;
   gap: $margin-xsm;
-  height: $spacing-lg;
   justify-content: center;
-  padding: 0 $padding-md;
+  padding: $snw-button-padding $padding-md;
   position: relative;
   transition:
     color 0.25s,

--- a/src/patterns/ObjectTile/_objectTile.scss
+++ b/src/patterns/ObjectTile/_objectTile.scss
@@ -39,8 +39,8 @@
 
     .#{$px}-object-tile__lot-badge {
       display: inline-block;
-      position: relative;
       padding-left: $spacing-xsm;
+      position: relative;
       transform: translateY(15%);
 
       svg {

--- a/src/patterns/SaleHeaderBanner/_saleHeaderBanner.scss
+++ b/src/patterns/SaleHeaderBanner/_saleHeaderBanner.scss
@@ -35,6 +35,10 @@
       display: flex;
       width: 100%;
     }
+
+    .#{$px}-text--badge {
+      margin-bottom: $spacing-xsm;
+    }
   }
 
   &__location {

--- a/src/patterns/SaleHeaderBanner/_saleHeaderBanner.scss
+++ b/src/patterns/SaleHeaderBanner/_saleHeaderBanner.scss
@@ -54,10 +54,10 @@
       &::after {
         content: '';
         display: block;
-        height: 1rem;
       }
 
       &:first-child {
+        margin-bottom: 1.5rem;
         padding-right: $spacing-sm;
       }
 


### PR DESCRIPTION
**Jira ticket**

[L3-5540 ](https://phillipsauctions.atlassian.net/browse/L3-5540)

Linked to this [PR](https://github.com/PhillipsAuctionHouse/phillips-public-remix/pull/821) in remix

**Screenshots**
| Before | After |
| ------ | ----- |
|![Screenshot 2025-02-28 140856](https://github.com/user-attachments/assets/85627c41-3e1e-4336-bf02-816f6e05f40e) | ![Screenshot 2025-02-28 155125](https://github.com/user-attachments/assets/c6d35df0-3720-42ba-baa3-6ed1f8f8b2e3) |

**Figma link**

[Figma Link](https://www.figma.com/design/OvBXAq48blO1r4qYbeBPjW/RW---Sale-Page-(PLP)?node-id=147-16379&m=dev)

**Summary**

Tweaks to the styles in sale header banner

**Change List (describe the changes made to the files)**
This pull request includes several changes to the SCSS files to improve the styling and layout of various components. The most important changes include adjustments to button styling, and sale header banner spacing.

Styling adjustments:

* [`src/components/Button/_button.scss`](diffhunk://#diff-e58c776e5ed2be781d57fc48c7f9045534becea19f9daf22e7853f0b69512d35L10-R18): Changed the `border-radius` to `6.25rem`, updated the `padding` to `0 $padding-md`, and set the `height` to `$spacing-lg`.

Layout improvements:

* [`src/patterns/SaleHeaderBanner/_saleHeaderBanner.scss`](diffhunk://#diff-29768014c7e5e596faebd0d6d885bae1b53f57174560bd072712cfda9a558fd9L57-R60): Added a `margin-bottom` of `1.5rem` to the first child and removed the `height` property from the `::after` pseudo-element.

**Acceptance Test (how to verify the PR)**

Verify that the changes match the figma linked in this PR

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
