### PR TITLE
feat(Icon): L3-3417 Part 1 - Add Icon component

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -1,0 +1,64 @@
+import { Meta } from '@storybook/react';
+import Icon, { IconName, IconProps } from './Icon';
+import * as iconComponents from '../../assets/formatted';
+import { getScssColors } from '../../utils/scssUtils';
+
+const colorOptions = getScssColors();
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
+const meta = {
+  title: 'Components/Icon',
+  component: Icon,
+  argTypes: {
+    height: { control: 'text' },
+    width: { control: 'text' },
+    color: { control: 'select', options: colorOptions },
+  },
+  args: {
+    height: 24,
+    width: 24,
+    color: '$primary-black',
+  },
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+
+export const IconGrid = (props: IconProps) => (
+  <div className="story-icon-flex-wrapper">
+    {Object.keys(iconComponents).map((icon) => (
+      <div className="icon-set" key={icon}>
+        <div className="icon-wrapper">
+          <Icon {...props} icon={icon as IconProps['icon']} />
+        </div>
+        <div className="icon-name">{icon}</div>
+      </div>
+    ))}
+  </div>
+);
+
+export const Playground = (props: IconProps) => (
+  <div className="story-icon-flex-wrapper">
+    <div className="icon-set">
+      <div className="icon-wrapper">
+        <Icon {...props} />
+      </div>
+      <div className="icon-name">{props.icon}</div>
+    </div>
+  </div>
+);
+
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
+Playground.args = {
+  icon: Object.keys(iconComponents)[0] as IconName,
+  height: 24,
+  width: 24,
+  color: '$pure-black',
+};
+
+Playground.argTypes = {
+  icon: { control: 'select', options: Object.keys(iconComponents) as IconName[] },
+  height: { control: 'text' },
+  width: { control: 'text' },
+  color: { control: 'select', options: colorOptions },
+  showBorder: { control: 'boolean' },
+};

--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -1,0 +1,42 @@
+import Icon from './Icon';
+import { render } from '@testing-library/react';
+
+const vars = vi.hoisted(() => '$pure-black: COLOR_DEFAULT;\n$test-color: COLOR_RED;\n');
+vi.mock('#scss/_vars.scss?raw', () => ({ default: vars }));
+
+describe('Icon', () => {
+  it('should render the icon', () => {
+    const { getByTestId } = render(<Icon icon="AccountCircle" />);
+    expect(getByTestId('icon-account-circle')).toBeInTheDocument();
+  });
+
+  it('should render the icon with the proper test id', () => {
+    const { getByTestId } = render(<Icon icon="Calendar" />);
+    expect(getByTestId('icon-calendar')).toBeInTheDocument();
+  });
+
+  it('should apply correct height and width styles based on props', () => {
+    const { getByTestId } = render(<Icon icon="AccountCircle" height={32} width={32} color="$pure-black" />);
+    const icon = getByTestId('icon-account-circle');
+    expect(icon).toHaveAttribute('height', '32');
+    expect(icon).toHaveAttribute('width', '32');
+  });
+
+  it('should apply correct color style based on prop', () => {
+    const { getByTestId } = render(<Icon icon="AccountCircle" height={32} width={32} color="$test-color" />);
+    const icon = getByTestId('icon-account-circle');
+    expect(icon).toHaveAttribute('fill', 'COLOR_RED');
+  });
+
+  it('should apply default color if color prop is not found in vars', () => {
+    const { getByTestId } = render(<Icon icon="AccountCircle" height={32} width={32} color="$fake-color" />);
+    const icon = getByTestId('icon-account-circle');
+    expect(icon).toHaveAttribute('fill', '$pure-black');
+  });
+
+  it('should return null if icon does not exist', () => {
+    // @ts-expect-error icon prop must match existing icon names
+    const { container } = render(<Icon icon="FakeIcon" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,0 +1,57 @@
+import { forwardRef } from 'react';
+import classnames from 'classnames';
+import { getCommonProps, px } from '../../utils';
+import { getScssVar } from '../../utils/scssUtils';
+import * as iconComponents from '../../assets/formatted';
+
+export type IconName = keyof typeof iconComponents;
+
+export interface IconProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Height of the icon in px (number) or as a string with units (e.g. '1em')
+   */
+  height?: number | string | null;
+  /**
+   * Width of the icon in px (number) or as a string with units (e.g. '1em')
+   */
+  width?: number | string | null;
+  /**
+   * Color of the icon. Only accepts valid seldon color tokens. Defaults to $pure-black
+   */
+  color?: string;
+  /**
+   * Name of Icon to render
+   */
+  icon: IconName;
+}
+
+/**
+ * ## Overview
+ *
+ * Component for rendering icons. Accepts an icon name and renders the corresponding SVG icon at the height and width specified. Also accepts a color parameter to change the fill color of the icon, but not all icons can be recolored (Business logos for example).
+ *
+ * [Storybook Link](https://phillips-seldon.netlify.app/?path=/docs/components-icon--overview)
+ */
+const Icon = forwardRef<HTMLDivElement, IconProps>(
+  ({ className, height, width, color, icon, ...props }: IconProps, ref) => {
+    const { className: baseClassName, ...commonProps } = getCommonProps(props, `Icon-${icon}`);
+
+    const Component = iconComponents[icon];
+    const componentProps = {
+      color: getScssVar(color ?? '', '$pure-black'),
+      ...(height ? { height } : {}),
+      ...(width ? { width } : {}),
+      ...commonProps,
+    };
+
+    return Component ? (
+      <div className={classnames(`${px}-icon`, baseClassName, className)} ref={ref}>
+        <Component {...componentProps} />
+      </div>
+    ) : null;
+  },
+);
+
+Icon.displayName = 'Icon';
+
+export default Icon;

--- a/src/components/Icon/_icon.stories.scss
+++ b/src/components/Icon/_icon.stories.scss
@@ -1,0 +1,32 @@
+@import '#scss/allPartials';
+
+.story-icon-flex-wrapper {
+  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 20%);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: 24px;
+  padding: 24px;
+  width: fit-content;
+
+  .icon-set {
+    display: flex;
+    flex-direction: column;
+    margin: 24px 12px;
+  }
+
+  .icon-name {
+    padding: 8px;
+    text-align: center;
+
+    @include text($string2);
+  }
+
+  .icon-wrapper {
+    &.show-border {
+      border: 1px solid black;
+    }
+
+    margin: 0 auto;
+  }
+}

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,0 +1,1 @@
+export { default as Icon, type IconProps, type IconName } from './Icon';

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,3 +97,4 @@ export * from './components/Countdown/types';
 export * from './patterns/ObjectTile';
 export * from './patterns/BidSnapshot';
 export * from './components/Article';
+export * from './components/Icon';

--- a/src/utils/scssUtils.test.ts
+++ b/src/utils/scssUtils.test.ts
@@ -1,0 +1,31 @@
+import { getScssColors, getScssVar } from './scssUtils';
+
+const vars = vi.hoisted(() => '$pure-black: #000000;\n$cta-blue: #0077FF;\n$error-red: #FF0000;\n');
+vi.mock('#scss/_vars.scss?raw', () => ({ default: vars }));
+
+describe('scssUtils', () => {
+  describe('getScssVar', () => {
+    it('should return the value of the scss variable if it exists', () => {
+      const scssVar = '$pure-black';
+      const defaultValue = '$error-red';
+
+      const result = getScssVar(scssVar, defaultValue);
+      expect(result).toBe('#000000');
+    });
+
+    it('should return the default value if the scss variable does not exist', () => {
+      const scssVar = '$non-existent-var';
+      const defaultValue = '$error-red';
+
+      const result = getScssVar(scssVar, defaultValue);
+      expect(result).toBe('$error-red');
+    });
+  });
+
+  describe('getScssColors', () => {
+    it('should return an array of color variables from _vars.scss', () => {
+      const result = getScssColors();
+      expect(result).toEqual(['$pure-black', '$cta-blue', '$error-red']);
+    });
+  });
+});

--- a/src/utils/scssUtils.ts
+++ b/src/utils/scssUtils.ts
@@ -8,7 +8,6 @@ export const getScssVar = (scssVar: string, defaultValue: string): string => {
     return { name, value: value?.replace(';', '') };
   });
   const colorIndex = parsedVars.findIndex(({ name }) => name === scssVar);
-  console.log('parsedVars', parsedVars);
 
   if (scssVar && colorIndex > -1) {
     return parsedVars[colorIndex].value;

--- a/src/utils/scssUtils.ts
+++ b/src/utils/scssUtils.ts
@@ -1,0 +1,35 @@
+import vars from '#scss/_vars.scss?raw';
+
+// This function parses the _vars.scss file into individual lines and returns the value of the variable passed in
+// If the variable is not found, it returns the default value passed in
+export const getScssVar = (scssVar: string, defaultValue: string): string => {
+  const parsedVars = vars.split('\n').map((_var) => {
+    const [name, value] = _var.split(': ');
+    return { name, value: value?.replace(';', '') };
+  });
+  const colorIndex = parsedVars.findIndex(({ name }) => name === scssVar);
+  console.log('parsedVars', parsedVars);
+
+  if (scssVar && colorIndex > -1) {
+    return parsedVars[colorIndex].value;
+  }
+
+  return defaultValue;
+};
+
+// Finds all color variables set in _vars.scss and returns the name of each
+export const getScssColors = (): string[] => {
+  const parsedVars = vars.split('\n');
+
+  const colors: string[] = parsedVars
+    .map((_var) => {
+      const [name, value] = _var.split(': ');
+      if (!!name && !!value && value.startsWith('#') && value.length === 8) {
+        return name; // returning only the name of each color variable
+      }
+      return null;
+    })
+    .filter((color): color is string => color !== null);
+
+  return colors;
+};


### PR DESCRIPTION
**Jira ticket**

[L3-3417](https://phillipsauctions.atlassian.net/browse/L3-3417)

**Summary**

Part 1/4 of the changes for the Sale and Lot icon changes. This PR adds the `Icon` component that will be used for rendering resizable and recolorable svgs.

**Change List (describe the changes made to the files)**

This pull request introduces a new `Icon` component to the codebase, along with associated stories, tests, and utility functions for handling SCSS variables. The changes include the implementation of the `Icon` component, its stories for Storybook, unit tests, and updates to SCSS utilities and styles.

### New `Icon` Component Implementation:

* [`src/components/Icon/Icon.tsx`](diffhunk://#diff-08acd9c461dd2b3858a54d0dd361b9164bdc650ee0050ace49c108d9dc6e2059R1-R57): Created the `Icon` component with support for height, width, color, and icon name props. The component uses SCSS variables for colors and renders the corresponding SVG icon.
* [`src/components/Icon/index.ts`](diffhunk://#diff-260882b2381f27d4317564fe327070e83fd95157e17c32169ba98b5a333e2aedR1): Exported the `Icon` component and its types.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R100): Added export for the new `Icon` component.

### Storybook Stories:

* [`src/components/Icon/Icon.stories.tsx`](diffhunk://#diff-fb3288e57d3702f6bb834ad60d9f415f9d4a55ae87699bb979e92678888b14e7R1-R64): Added Storybook stories for the `Icon` component, including a grid view of all icons and a playground for interactive testing.
* [`src/components/Icon/_icon.stories.scss`](diffhunk://#diff-23b53619aabb06faff10913e9fbbdc25b4d11947b3cbcc87f5629ef93caf47afR1-R32): Added SCSS styles for the Storybook stories to display icons in a grid layout.

### Unit Tests:

* [`src/components/Icon/Icon.test.tsx`](diffhunk://#diff-417656a63db170a14e50704cf3e576d0bbf921441661c99d965eecd3cc2b973aR1-R42): Added unit tests for the `Icon` component to verify rendering, prop handling, and default values.

### SCSS Utilities:

* [`src/utils/scssUtils.ts`](diffhunk://#diff-5e62e3c736aee0039f5f756b51b4611e7ab9fc3004b5b984e433df188f366a18R1-R35): Added utility functions `getScssVar` and `getScssColors` to handle SCSS variables and colors.
* [`src/utils/scssUtils.test.ts`](diffhunk://#diff-3cb6b53e2901364c67f3cd2d53c55eef0079cd6565cf4f000adbd6837c4324eaR1-R31): Added unit tests for the SCSS utility functions to ensure correct parsing and retrieval of SCSS variables.

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-3417]: https://phillipsauctions.atlassian.net/browse/L3-3417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ