### PR TITLE
feat(Icon): L3-3417 Part 3 - component updates

### DIFF
--- a/src/components/Accordion/AccordionItem.tsx
+++ b/src/components/Accordion/AccordionItem.tsx
@@ -1,9 +1,7 @@
 import * as Accordion from '@radix-ui/react-accordion';
 import classnames from 'classnames';
 import React, { forwardRef, useCallback, useRef } from 'react';
-import LockIcon from '../../assets/lock.svg?react';
-import MinusIcon from '../../assets/minus.svg?react';
-import PlusIcon from '../../assets/plus.svg?react';
+import { Icon } from '../Icon';
 import { getCommonProps } from '../../utils';
 import { AccordionContentType, AccordionHeaderType, AccordionItemVariant } from './types';
 import { getIconClasses } from './utils';
@@ -72,7 +70,10 @@ const AccordionHeader = ({
   // Render all icons and use css to conditionally show/hide the correct one
   const lockIconComponent = (
     <div>
-      <LockIcon
+      <Icon
+        icon="Lock"
+        height={24}
+        width={24}
         className={getIconClasses(baseClassName, isLargeVariation, 'lock')}
         data-testid={`${id}-lockedIcon`}
         aria-hidden
@@ -82,7 +83,10 @@ const AccordionHeader = ({
 
   const plusIconComponent = (
     <div>
-      <PlusIcon
+      <Icon
+        icon="Plus"
+        height={24}
+        width={24}
         className={getIconClasses(baseClassName, isLargeVariation, 'plus')}
         data-testid={`${id}-plusIcon`}
         aria-hidden
@@ -92,7 +96,10 @@ const AccordionHeader = ({
 
   const minusIconComponent = (
     <div>
-      <MinusIcon
+      <Icon
+        icon="Minus"
+        height={24}
+        width={24}
         className={getIconClasses(baseClassName, isLargeVariation, 'minus')}
         data-testid={`${id}-minusIcon`}
         aria-hidden

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -3,7 +3,7 @@ import { getCommonProps, px } from '../../utils';
 import classnames from 'classnames';
 import BreadcrumbItem, { BreadcrumbItemProps } from './BreadcrumbItem';
 import { SSRMediaQuery } from '../../providers/SeldonProvider/utils';
-import ArrowPrevIcon from '../../assets/arrowPrev.svg?react';
+import { Icon } from '../Icon';
 
 export interface BreadcrumbProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -52,7 +52,7 @@ const Breadcrumb = ({
           className={`${px}-icon-button ${px}-icon-button--primary ${baseClassName}__back-button`} // apply button styles though it's a link
           data-testid={`${id}-back-button`}
         >
-          <ArrowPrevIcon />
+          <Icon icon="ArrowPrev" />
         </CustomElement>
       </SSRMediaQuery.Media>
       {/* This is not visible when in mobile breakpoint */}

--- a/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { getCommonProps } from '../../utils';
 import classnames from 'classnames';
-import ChevronNextIcon from '../../assets/chevronNext.svg?react';
+import { Icon } from '../Icon';
 
 export interface BreadcrumbItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -61,7 +61,7 @@ const BreadcrumbItem = ({
         </CustomElement>
       )}
 
-      {!isCurrent ? <ChevronNextIcon className={`${baseClassName}__chevron`} /> : null}
+      {!isCurrent ? <Icon icon="ChevronNext" className={`${baseClassName}__chevron`} /> : null}
     </li>
   );
 };

--- a/src/components/Carousel/CarouselArrows.tsx
+++ b/src/components/Carousel/CarouselArrows.tsx
@@ -2,14 +2,14 @@ import classNames from 'classnames';
 import { ComponentProps, forwardRef, useCallback } from 'react';
 import { getCommonProps } from '../../utils';
 import { useCarousel } from './utils';
-import { CarouselArrowNext, CarouselArrowPrev } from '../../assets/icons';
+import { Icon } from '../Icon';
 
 export type CarouselArrowsProps = ComponentProps<'div'>;
 
 /**
  * ## Overview
  *
- * Arrow naivigation for the carousel.
+ * Arrow navigation for the carousel.
  *
  */
 const CarouselArrows = forwardRef<HTMLDivElement, CarouselArrowsProps>(({ className, ...props }, ref) => {
@@ -35,12 +35,12 @@ const CarouselArrows = forwardRef<HTMLDivElement, CarouselArrowsProps>(({ classN
     >
       <button data-testid="prev-arrow" className={`${baseClassName}-prev-btn`} onClick={() => onPrevArrowClick()}>
         <div className={`${baseClassName}-prev-btn__icon`}>
-          <CarouselArrowPrev />
+          <Icon icon="CarouselArrowPrev" height={32} width={16} />
         </div>
       </button>
       <button data-testid="next-arrow" className={`${baseClassName}-next-btn`} onClick={() => onNextArrowClick()}>
         <div className={`${baseClassName}-next-btn__icon`}>
-          <CarouselArrowNext />
+          <Icon icon="CarouselArrowNext" height={32} width={16} />
         </div>
       </button>
     </div>

--- a/src/components/ContentPeek/ContentPeek.tsx
+++ b/src/components/ContentPeek/ContentPeek.tsx
@@ -4,10 +4,9 @@ import { getCommonProps } from '../../utils';
 import Button from '../Button/Button';
 import { ButtonVariants } from '../Button/types';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../Collapsible';
-import PlusIcon from '../../assets/plus.svg?react';
-import MinusIcon from '../../assets/minus.svg?react';
 import { HeightUnits } from './utils';
 import { DEFAULT_REM_SIZE } from '../../utils/constants';
+import { Icon } from '../Icon';
 
 export interface ContentPeekProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -113,7 +112,7 @@ const ContentPeek = forwardRef<HTMLDivElement, ContentPeekProps>(
             <div className={`${baseClassName}-overlay-trigger-wrapper`}>
               <CollapsibleTrigger asChild className={`${baseClassName}-overlay-trigger`}>
                 <Button variant={ButtonVariants.secondary}>
-                  {isExpanded ? <MinusIcon /> : <PlusIcon />}
+                  {isExpanded ? <Icon icon="Minus" /> : <Icon icon="Plus" />}
                   {isExpanded ? contentCollapseText : contentExpandText}
                 </Button>
               </CollapsibleTrigger>

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { getCommonProps, noOp } from '../../utils';
 import classnames from 'classnames';
 import * as Dialog from '@radix-ui/react-dialog';
-import CloseIcon from '../../assets/close.svg?react';
 import IconButton from '../IconButton/IconButton';
 import { ButtonVariants } from '../Button/types';
+import { Icon } from '../Icon';
 
 // You'll need to change the HTMLDivElement to match the top-level element of your component
 export interface DrawerProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -56,7 +56,7 @@ const Drawer = ({ className, isOpen = false, onClose = noOp, children, ...props 
               data-testid="drawer-close"
               variant={ButtonVariants.tertiary}
             >
-              <CloseIcon />
+              <Icon icon="Close" />
             </IconButton>
           </Dialog.Close>
           {children}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,8 +2,8 @@ import React, { useState, ComponentPropsWithoutRef } from 'react';
 import { getCommonProps } from '../../utils';
 import classnames from 'classnames';
 import * as DropdownSelect from '@radix-ui/react-select';
-import ChevronDownIcon from '../../assets/chevronDown.svg?react';
 import { DropdownItem } from './types';
+import { Icon } from '../Icon';
 
 export interface DropdownProps
   extends Omit<DropdownSelect.SelectProps, 'defaultValue' | 'dir'>,
@@ -61,13 +61,18 @@ const Dropdown = React.forwardRef<HTMLButtonElement, DropdownProps>(
           >
             <DropdownSelect.Value placeholder={value} />
             <DropdownSelect.Icon>
-              {<ChevronDownIcon className={classnames({ [`${baseClassName}__trigger-icon-expanded`]: isOpen })} />}
+              {
+                <Icon
+                  icon="ChevronDown"
+                  className={classnames({ [`${baseClassName}__trigger-icon-expanded`]: isOpen })}
+                />
+              }
             </DropdownSelect.Icon>
           </DropdownSelect.Trigger>
           <DropdownSelect.Portal>
             <DropdownSelect.Content className={`${baseClassName}__content`} position="popper">
               <DropdownSelect.ScrollUpButton className={`${baseClassName}__scroll-button__up`}>
-                <ChevronDownIcon />
+                <Icon icon="ChevronDown" />
               </DropdownSelect.ScrollUpButton>
               <DropdownSelect.Viewport className={`${baseClassName}__viewport`}>
                 {options.map((option) => (
@@ -82,7 +87,7 @@ const Dropdown = React.forwardRef<HTMLButtonElement, DropdownProps>(
                 ))}
               </DropdownSelect.Viewport>
               <DropdownSelect.ScrollDownButton className={`${baseClassName}__scroll-button`}>
-                <ChevronDownIcon />
+                <Icon icon="ChevronDown" />
               </DropdownSelect.ScrollDownButton>
             </DropdownSelect.Content>
           </DropdownSelect.Portal>

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -14,7 +14,7 @@ import FilterHeader from './FilterHeader';
 import { FilterInputProps } from './FilterInput';
 import Button from '../Button/Button';
 import { ButtonVariants } from '../Button/types';
-import ChevronNextIcon from '../../assets/chevronNext.svg?react';
+import { Icon } from '../Icon';
 
 export interface FilterProps extends ComponentProps<'div'> {
   /** Logical name of this filter */
@@ -102,7 +102,7 @@ const Filter = forwardRef<HTMLDivElement, FilterProps>(
             }}
           >
             {viewAllLabel}
-            <ChevronNextIcon className={`${baseClassName}__chevron`} />
+            <Icon icon="ChevronNext" className={`${baseClassName}__chevron`} />
           </Button>
         ) : null}
       </div>

--- a/src/components/Filter/FilterHeader.tsx
+++ b/src/components/Filter/FilterHeader.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { Text, TextVariants } from '../Text';
 import Button from '../Button/Button';
 import { ButtonVariants } from '../Button/types';
-import ChevronNextIcon from '../../assets/chevronNext.svg?react';
+import { Icon } from '../Icon';
 
 export interface FilterHeaderProps extends ComponentProps<'div'> {
   // Text to display as the header
@@ -46,7 +46,7 @@ const FilterHeader = forwardRef<HTMLDivElement, FilterHeaderProps>(
         />
         {isViewingAll ? (
           <Button variant={ButtonVariants.tertiary} onClick={handleClose} className={`${baseClassName}__back`}>
-            <ChevronNextIcon className={`${baseClassName}__chevron`} />
+            <Icon icon="ChevronNext" className={`${baseClassName}__chevron`} />
             Back to all
           </Button>
         ) : null}

--- a/src/components/IconButton/_iconButton.scss
+++ b/src/components/IconButton/_iconButton.scss
@@ -8,7 +8,7 @@
   padding: 0;
   width: $spacing-md;
 
-  & > svg {
+  & svg {
     height: $button-label-line-height;
     width: $button-label-line-height;
   }
@@ -29,7 +29,7 @@
     background: $pure-white;
     color: $pure-black;
 
-    & > svg {
+    & svg {
       fill: $pure-black;
       height: calc($button-label-line-height * 1.5); // design-cheats-for-button-large
       margin-inline-end: unset;
@@ -93,10 +93,9 @@
     &:hover {
       background-color: $button-hover;
 
-      & > svg {
+      & svg {
         fill: $pure-white;
         margin-inline-end: unset;
-        position: absolute;
 
         path {
           fill: $pure-white;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import classnames from 'classnames';
 import { getCommonProps, noOp } from '../../utils';
-import CloseIcon from '../../assets/close.svg?react';
+import { Icon } from '../Icon';
 import ReactModal from 'react-modal';
 import IconButton from '../IconButton/IconButton';
 import { ButtonVariants } from '../Button/types';
@@ -82,7 +82,7 @@ const Modal = ({
         className={classnames(`${baseClassName}__close`)}
         variant={ButtonVariants.tertiary}
       >
-        <CloseIcon />
+        <Icon icon="Close" height={32} width={32} />
       </IconButton>
       {children}
     </ReactModal>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -4,12 +4,12 @@ import { getCommonProps } from '../../utils';
 import { px } from '../../utils';
 
 import Select from '../Select/Select';
-import ChevronRight from '../../assets/chevronRight.svg?react';
 import IconButton from '../IconButton/IconButton';
 import { ButtonVariants } from '../Button/types';
 import { determineOptionValue, findOptionFromSelectString } from './utils';
 import { usePendingState } from '../../utils/hooks';
 import { ButtonProps } from '../Button/Button';
+import { Icon } from '../Icon';
 
 export type PaginationOptionValue = string | number;
 
@@ -146,7 +146,7 @@ const Pagination = ({
         href={typeof prevOption === 'object' && prevOption.href ? prevOption.href : undefined}
         prefetch={typeof prevOption === 'object' && prevOption.prefetch ? prevOption.prefetch : undefined}
       >
-        <ChevronRight />
+        <Icon icon="ChevronRight" />
       </IconButton>
 
       <Select
@@ -192,7 +192,7 @@ const Pagination = ({
         href={typeof nextOption === 'object' && nextOption.href ? nextOption.href : undefined}
         prefetch={typeof nextOption === 'object' && nextOption.prefetch ? nextOption.prefetch : undefined}
       >
-        <ChevronRight />
+        <Icon icon="ChevronRight" />
       </IconButton>
     </div>
   );

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -15,7 +15,7 @@
       opacity: 0.15;
       pointer-events: none;
 
-      svg path {
+      .#{$px}-icon path {
         fill: $pure-black;
       }
     }
@@ -23,7 +23,7 @@
     &:hover:not(:disabled) {
       background-color: inherit;
 
-      svg path {
+      .#{$px}-icon path {
         fill: $pure-black;
       }
     }

--- a/src/components/Search/SearchButton.tsx
+++ b/src/components/Search/SearchButton.tsx
@@ -1,6 +1,5 @@
+import { Icon } from '../Icon';
 import { SearchProps } from './Search';
-import SearchIcon from '../../assets/search.svg?react';
-import CloseIcon from '../../assets/close.svg?react';
 import { ComponentProps } from 'react';
 
 export const SearchButton = ({
@@ -31,7 +30,7 @@ export const SearchButton = ({
           event.stopPropagation();
         }}
       >
-        <SearchIcon data-testid={`${testId}-button-icon`} className={`${className}__button__icon`} />
+        <Icon icon="Search" data-testid={`${testId}-button-icon`} className={`${className}__button__icon`} />
       </button>
     );
   }
@@ -50,7 +49,7 @@ export const SearchButton = ({
           event.stopPropagation();
         }}
       >
-        <CloseIcon data-testid={`${testId}-form-icon`} className={`${className}__button__icon`} />
+        <Icon icon="Close" data-testid={`${testId}-form-icon`} className={`${className}__button__icon`} />
       </button>
     );
   }

--- a/src/components/SeldonImage/SeldonImage.tsx
+++ b/src/components/SeldonImage/SeldonImage.tsx
@@ -2,7 +2,8 @@ import { ComponentProps, forwardRef, useRef, useState, useEffect, useCallback, m
 import classnames from 'classnames';
 
 import { getCommonProps } from '../../utils';
-import { PhillipsLogo } from '../../assets/icons';
+import { Icon } from '../Icon';
+import { isImageValid } from './utils';
 
 type AspectRatio = '16/9' | '1/1' | 'none';
 
@@ -55,39 +56,6 @@ export interface SeldonImageProps extends ComponentProps<'div'> {
    * The text to display when the image fails to load.
    */
   errorText?: string;
-}
-
-function isImageValid({
-  img,
-  src,
-  srcSet,
-  sizes,
-}: {
-  img: HTMLImageElement | null;
-  src: string;
-  srcSet?: string;
-  sizes?: string;
-}) {
-  const promise = new Promise((resolve) => {
-    let imgElement = img;
-    if (!imgElement) {
-      imgElement = document.createElement('img');
-    }
-    imgElement.onerror = () => resolve(false);
-    imgElement.onload = () => resolve(true);
-    if (srcSet) {
-      imgElement.srcset = srcSet;
-    }
-    if (sizes) {
-      imgElement.sizes = sizes;
-    }
-    imgElement.src = src;
-    if (imgElement.complete) {
-      resolve(true);
-    }
-  });
-
-  return promise;
 }
 
 const isServer = typeof window === 'undefined';
@@ -189,7 +157,7 @@ const SeldonImage = memo(
           )}
           {loadingState === 'error' ? (
             <div className={`${baseClassName}--error`}>
-              <PhillipsLogo aria-label={errorText} />
+              <Icon icon="PhillipsLogo" aria-label={errorText} role="img" />
             </div>
           ) : null}
           <img

--- a/src/components/SeldonImage/utils.test.ts
+++ b/src/components/SeldonImage/utils.test.ts
@@ -1,0 +1,74 @@
+import { isImageValid } from './utils';
+import { vi } from 'vitest';
+
+describe('utils', () => {
+  describe('isImageValid', () => {
+    beforeEach(() => {
+      global.Image = vi.fn().mockImplementation(() => {
+        return {
+          onload: null,
+          onerror: null,
+          src: null,
+        };
+      });
+    });
+
+    it('should return a promise that resolves to true if the image is valid', async () => {
+      const validImageUrl = 'https://example.com/valid-image.jpg';
+
+      // Mock the Image instance to trigger onload when src is set
+      global.Image = vi.fn().mockImplementation(() => {
+        const image = {
+          onload: null,
+          onerror: null,
+          src: null,
+        };
+
+        // Use setTimeout to simulate async behavior
+        Object.defineProperty(image, 'src', {
+          set(value) {
+            this._src = value;
+            setTimeout(() => this.onload());
+          },
+          get() {
+            return this._src;
+          },
+        });
+
+        return image;
+      });
+
+      const isValid = await isImageValid({ img: new Image(), src: validImageUrl });
+      expect(isValid).toBe(true);
+    });
+
+    it('should return a promise that resolves to false if the image is invalid', async () => {
+      const invalidImageUrl = 'https://example.com/invalid-image.jpg';
+
+      // Mock the Image instance to trigger onerror when src is set
+      global.Image = vi.fn().mockImplementation(() => {
+        const image = {
+          onload: null,
+          onerror: null,
+          src: null,
+        };
+
+        // Use setTimeout to simulate async behavior
+        Object.defineProperty(image, 'src', {
+          set(value) {
+            this._src = value;
+            setTimeout(() => this.onerror());
+          },
+          get() {
+            return this._src;
+          },
+        });
+
+        return image;
+      });
+
+      const isValid = await isImageValid({ img: new Image(), src: invalidImageUrl });
+      expect(isValid).toBe(false);
+    });
+  });
+});

--- a/src/components/SeldonImage/utils.ts
+++ b/src/components/SeldonImage/utils.ts
@@ -1,0 +1,32 @@
+export function isImageValid({
+  img,
+  src,
+  srcSet,
+  sizes,
+}: {
+  img: HTMLImageElement | null;
+  src: string;
+  srcSet?: string;
+  sizes?: string;
+}) {
+  const promise = new Promise((resolve) => {
+    let imgElement = img;
+    if (!imgElement) {
+      imgElement = document.createElement('img');
+    }
+    imgElement.onerror = () => resolve(false);
+    imgElement.onload = () => resolve(true);
+    if (srcSet) {
+      imgElement.srcset = srcSet;
+    }
+    if (sizes) {
+      imgElement.sizes = sizes;
+    }
+    imgElement.src = src;
+    if (imgElement.complete) {
+      resolve(true);
+    }
+  });
+
+  return promise;
+}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -5,7 +5,7 @@ import { InputProps } from '../Input/Input';
 import { Merge } from 'type-fest';
 
 import { SelectVariants } from './types';
-import ChevronDownIcon from '../../assets/chevronDown.svg?react';
+import { Icon } from '../Icon';
 
 export interface SelectProps extends Merge<InputProps, React.ComponentProps<'select'>> {
   /**
@@ -110,7 +110,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           >
             {children}
           </select>
-          {showIcon ? <ChevronDownIcon /> : null}
+          {showIcon ? <Icon icon="ChevronDown" /> : null}
         </div>
         {inputProps.validation}
       </div>

--- a/src/components/Tags/Tags.tsx
+++ b/src/components/Tags/Tags.tsx
@@ -4,8 +4,7 @@ import { getCommonProps } from '../../utils';
 import { px } from '../../utils';
 import Button from '../Button/Button';
 import { ButtonVariants } from '../Button/types';
-import CloseIcon from '../../assets/close.svg?react';
-import { ArrowPrev } from '../../assets/icons';
+import { Icon } from '../Icon';
 
 export interface I18nObject {
   clearAllLabel?: string;
@@ -67,7 +66,7 @@ export const Tag = ({ id, className, onRemove, label, removeText = 'Remove' }: T
     >
       <div className={`${px}-tag__label`}>{label}</div>
       <div className={`${px}-tag__button`} data-testid={`${id}-item-close-button`}>
-        <CloseIcon />
+        <Icon icon="Close" height={24} width={24} />
       </div>
     </Button>
   );
@@ -108,7 +107,7 @@ const TagsList = forwardRef<HTMLUListElement, TagsListProps>(
               aria-label={clearAllLabel}
               variant={ButtonVariants.tertiary}
             >
-              <ArrowPrev />
+              <Icon icon="ArrowPrev" height={24} width={24} />
               <div className={`${px}-label`}>{clearAllLabel}</div>
             </Button>
           </li>

--- a/src/patterns/BidSnapshot/BidMessage.tsx
+++ b/src/patterns/BidSnapshot/BidMessage.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { getCommonProps } from '../../utils';
 import { Text, TextVariants } from '../../components/Text';
 import { BidMessageVariants } from './types';
-import { GreenCircle, RedCircle } from '../../assets/icons';
+import { Icon } from '../../components/Icon';
 
 export interface BidMessageProps extends ComponentProps<'p'> {
   /**
@@ -37,7 +37,12 @@ const BidMessage = ({
   ...props
 }: BidMessageProps) => {
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'BidMessage');
-  const icon = variant === BidMessageVariants.positive ? <GreenCircle /> : <RedCircle />;
+  const icon =
+    variant === BidMessageVariants.positive ? (
+      <Icon icon="IconGreenCircle" height={8} width={8} />
+    ) : (
+      <Icon icon="IconRedCircle" height={8} width={8} />
+    );
   return (
     <div {...commonProps} className={classnames(baseClassName, className)} {...props}>
       {hasIcon ? icon : null}

--- a/src/patterns/UserManagement/UserManagement.tsx
+++ b/src/patterns/UserManagement/UserManagement.tsx
@@ -1,10 +1,10 @@
 import { ComponentProps, ElementType, forwardRef, ReactNode } from 'react';
 import { getCommonProps, noOp } from '../../utils';
-import AccountCircle from '../../assets/account_circle.svg?react';
 import { LinkProps } from '../../components/Link/Link';
 import classnames from 'classnames';
 import { AuthState } from './types';
 import { Text, TextVariants } from '../../components/Text';
+import { Icon } from '../../components/Icon';
 
 export interface UserManagementProps extends ComponentProps<'div'> {
   /**
@@ -63,12 +63,22 @@ const UserManagement = forwardRef<HTMLDivElement, UserManagementProps>(
           <>
             {isLoggedIn ? (
               <AccountDetailsComponent className={`${baseClassName}__login`} href={href} disabled={disabled}>
-                <AccountCircle className={`${baseClassName}__account-icon`} />
+                <Icon
+                  icon="AccountCircle"
+                  className={`${baseClassName}__account-icon`}
+                  height="1.5rem"
+                  width="1.5rem"
+                />
                 <Text variant={TextVariants.body3}>{accountLabel}</Text>
               </AccountDetailsComponent>
             ) : (
               <button className={`${baseClassName}__login`} onClick={onLogin} disabled={disabled}>
-                <AccountCircle className={`${baseClassName}__account-icon`} />
+                <Icon
+                  icon="AccountCircle"
+                  className={`${baseClassName}__account-icon`}
+                  height="1.5rem"
+                  width="1.5rem"
+                />
                 <Text variant={TextVariants.body3}>{loginLabel}</Text>
               </button>
             )}

--- a/src/patterns/UserManagement/_userManagement.scss
+++ b/src/patterns/UserManagement/_userManagement.scss
@@ -55,9 +55,6 @@
   }
 
   &__account-icon {
-    height: 1.5rem;
-    width: 1.5rem;
-
     a {
       align-items: center;
       display: flex;

--- a/src/site-furniture/Footer/Footer.tsx
+++ b/src/site-furniture/Footer/Footer.tsx
@@ -1,8 +1,8 @@
 import classnames from 'classnames';
 
 import { defaultYear, px } from '../../utils';
-import Logo from '../../assets/PhillipsLogo.svg?react';
 import { Text, TextVariants } from '../../components/Text';
+import { Icon } from '../../components/Icon';
 
 export interface FooterProps extends React.HTMLAttributes<HTMLElement> {
   /**
@@ -34,7 +34,7 @@ const Footer = ({
       <div className={`${px}-footer__copyright`}>
         <h3 data-testid="footer-logo" className={`${px}-footer__logo`}>
           <a href="/" aria-label="logo">
-            <Logo />
+            <Icon icon="PhillipsLogo" />
           </a>
         </h3>
         <Text variant={TextVariants.body3}>{copyright}</Text>

--- a/src/site-furniture/Header/Header.tsx
+++ b/src/site-furniture/Header/Header.tsx
@@ -1,7 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import classnames from 'classnames';
 import { findChildrenExcludingTypes, findChildrenOfType, px } from '../../utils';
-import Logo from '../../assets/PhillipsLogo.svg?react';
 import UserManagement, { UserManagementProps } from '../../patterns/UserManagement/UserManagement';
 import { LanguageSelector, LanguageSelectorProps } from '../../patterns/LanguageSelector';
 import Navigation from '../../components/Navigation/Navigation';
@@ -9,6 +8,7 @@ import { Component, ComponentProps, forwardRef, ReactElement, useState, createCo
 import { defaultHeaderContext } from './utils';
 import { SSRMediaQuery } from '../../providers/SeldonProvider/utils';
 import { useMobileMenu } from './hooks';
+import { Icon } from '../../components/Icon';
 
 export interface HeaderProps extends ComponentProps<'header'> {
   /**
@@ -71,7 +71,7 @@ export const HeaderContext = createContext<HeaderContextType>(defaultHeaderConte
 const Header = forwardRef<HTMLElement, HeaderProps>(
   (
     {
-      logo = <Logo />,
+      logo = <Icon icon="PhillipsLogo" />,
       logoHref = '/',
       className,
       children,


### PR DESCRIPTION
**Jira ticket**

[L3-3417](https://phillipsauctions.atlassian.net/browse/L3-3417)

**Summary**

Part 3/4 of the changes for the Sale and Lot icon changes. This PR handles all of the component updates to support the new `Icon` component

**Change List (describe the changes made to the files)**

This pull request includes several updates to various components to standardize the use of the `Icon` component instead of directly importing SVG icons. This change enhances consistency and simplifies icon management across the codebase. Below are the most important changes grouped by theme:

### Accordion Component Updates:
* Replaced direct SVG imports (`LockIcon`, `MinusIcon`, `PlusIcon`) with the `Icon` component in `AccordionItem.tsx` to improve icon handling. [[1]](diffhunk://#diff-79f9c994e4003a75f85d4965935180c14141e3318cc85ee068872da77ba67c3bL4-R4) [[2]](diffhunk://#diff-79f9c994e4003a75f85d4965935180c14141e3318cc85ee068872da77ba67c3bL75-R76) [[3]](diffhunk://#diff-79f9c994e4003a75f85d4965935180c14141e3318cc85ee068872da77ba67c3bL85-R89) [[4]](diffhunk://#diff-79f9c994e4003a75f85d4965935180c14141e3318cc85ee068872da77ba67c3bL95-R102)

### Breadcrumb Component Updates:
* Updated `Breadcrumb.tsx` and `BreadcrumbItem.tsx` to use the `Icon` component instead of `ArrowPrevIcon` and `ChevronNextIcon` for better consistency. [[1]](diffhunk://#diff-9d690e67c8e83e322089ed292b529dbffece2baa3fd5085ba26a55fe42b39d98L6-R6) [[2]](diffhunk://#diff-9d690e67c8e83e322089ed292b529dbffece2baa3fd5085ba26a55fe42b39d98L55-R55) [[3]](diffhunk://#diff-69b362b80055999db90d70186c1fe99a827e6cdf89d3fc78b2e6f9d6bdc7abe0L4-R4) [[4]](diffhunk://#diff-69b362b80055999db90d70186c1fe99a827e6cdf89d3fc78b2e6f9d6bdc7abe0L64-R64)

### Carousel Component Updates:
* Modified `CarouselArrows.tsx` to replace `CarouselArrowNext` and `CarouselArrowPrev` SVG imports with the `Icon` component, ensuring uniform icon usage. [[1]](diffhunk://#diff-e56e79b11599c5856b444f3433828e154a3905a0e539a24f1dd237fb1994d953L5-R12) [[2]](diffhunk://#diff-e56e79b11599c5856b444f3433828e154a3905a0e539a24f1dd237fb1994d953L38-R43)

### ContentPeek and Drawer Component Updates:
* Updated `ContentPeek.tsx` and `Drawer.tsx` to use the `Icon` component instead of `PlusIcon`, `MinusIcon`, and `CloseIcon`, streamlining icon management. [[1]](diffhunk://#diff-a1b5766242130234dd3ce61f2126dce07409153529063d7fd70a01260dfb69cfL7-R9) [[2]](diffhunk://#diff-a1b5766242130234dd3ce61f2126dce07409153529063d7fd70a01260dfb69cfL116-R115) [[3]](diffhunk://#diff-464e6017a1c751664c8b52771851ee19f5dab565bd7e3dd5b0e5bb011374deebL5-R7) [[4]](diffhunk://#diff-464e6017a1c751664c8b52771851ee19f5dab565bd7e3dd5b0e5bb011374deebL59-R59)

### Dropdown and Filter Component Updates:
* Replaced `ChevronDownIcon` and `ChevronNextIcon` with the `Icon` component in `Dropdown.tsx`, `Filter.tsx`, and `FilterHeader.tsx` to maintain icon consistency. [[1]](diffhunk://#diff-32fa9ddaf531f010c646834b9023bf97df1cd80d6de82762a56bc99514594f83L5-R6) [[2]](diffhunk://#diff-32fa9ddaf531f010c646834b9023bf97df1cd80d6de82762a56bc99514594f83L64-R75) [[3]](diffhunk://#diff-32fa9ddaf531f010c646834b9023bf97df1cd80d6de82762a56bc99514594f83L85-R90) [[4]](diffhunk://#diff-5731a1939deb75791a9ca01ee57d546eacc35eaa3dff78d670a8bfac6aec2f6bL17-R17) [[5]](diffhunk://#diff-5731a1939deb75791a9ca01ee57d546eacc35eaa3dff78d670a8bfac6aec2f6bL105-R105) [[6]](diffhunk://#diff-c6bf09217e7854dd948243a4d44ebef9f90fdc94c80e07be17a8eeb195d40331L7-R7) [[7]](diffhunk://#diff-c6bf09217e7854dd948243a4d44ebef9f90fdc94c80e07be17a8eeb195d40331L49-R49)

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-3417]: https://phillipsauctions.atlassian.net/browse/L3-3417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ