### PR TITLE
feat(Grid): L3-6072 Add support for xl breakpoints and colStart props

### DIFF
--- a/src/components/GridItem/GridItem.stories.tsx
+++ b/src/components/GridItem/GridItem.stories.tsx
@@ -139,21 +139,108 @@ export const GridWithOffsetColumns = () => (
         mdColStart={4}
         lg={6}
         lgColStart={7}
+        xl={6}
+        xlColStart={7}
         itemNum={1}
         align={GridItemAlign.left}
       />
     </GridWrapper>
     <GridWrapper title="2 Children (2 column layout)">
-      <GridChild xs={1} sm={1} md={2} mdColStart={1} lg={4} lgColStart={2} itemNum={1} align={GridItemAlign.left} />
-      <GridChild xs={1} sm={1} md={2} mdColStart={5} lg={4} lgColStart={8} itemNum={2} align={GridItemAlign.right} />
+      <GridChild
+        xs={1}
+        sm={1}
+        md={2}
+        mdColStart={1}
+        lg={4}
+        lgColStart={2}
+        xl={4}
+        xlColStart={2}
+        itemNum={1}
+        align={GridItemAlign.left}
+      />
+      <GridChild
+        xs={1}
+        sm={1}
+        md={2}
+        mdColStart={5}
+        lg={4}
+        lgColStart={8}
+        xl={4}
+        xlColStart={8}
+        itemNum={2}
+        align={GridItemAlign.right}
+      />
     </GridWrapper>
     <GridWrapper title="6 Children (Funky layout)">
-      <GridChild xs={2} sm={2} md={1} lg={1} lgColStart={2} itemNum={1} align={GridItemAlign.left} />
-      <GridChild xs={1} sm={1} smColStart={2} md={4} lg={1} lgColStart={4} itemNum={2} align={GridItemAlign.left} />
-      <GridChild xs={2} sm={2} md={1} lg={1} lgColStart={6} itemNum={3} align={GridItemAlign.left} />
-      <GridChild xs={1} sm={1} smColStart={2} md={1} lg={1} lgColStart={7} itemNum={4} align={GridItemAlign.left} />
-      <GridChild xs={2} sm={2} md={4} lg={1} lgColStart={9} itemNum={5} align={GridItemAlign.left} />
-      <GridChild xs={1} sm={1} smColStart={2} md={1} lg={1} lgColStart={11} itemNum={6} align={GridItemAlign.left} />
+      <GridChild
+        xs={2}
+        sm={2}
+        md={1}
+        lg={1}
+        lgColStart={2}
+        xl={2}
+        xlColStart={11}
+        itemNum={1}
+        align={GridItemAlign.left}
+      />
+      <GridChild
+        xs={1}
+        sm={1}
+        smColStart={2}
+        md={4}
+        lg={1}
+        lgColStart={4}
+        xl={2}
+        xlColStart={9}
+        itemNum={2}
+        align={GridItemAlign.left}
+      />
+      <GridChild
+        xs={2}
+        sm={2}
+        md={1}
+        lg={1}
+        lgColStart={6}
+        xl={2}
+        xlColStart={7}
+        itemNum={3}
+        align={GridItemAlign.left}
+      />
+      <GridChild
+        xs={1}
+        sm={1}
+        smColStart={2}
+        md={1}
+        lg={1}
+        lgColStart={7}
+        xl={2}
+        xlColStart={5}
+        itemNum={4}
+        align={GridItemAlign.left}
+      />
+      <GridChild
+        xs={2}
+        sm={2}
+        md={4}
+        lg={1}
+        lgColStart={9}
+        xl={2}
+        xlColStart={3}
+        itemNum={5}
+        align={GridItemAlign.left}
+      />
+      <GridChild
+        xs={1}
+        sm={1}
+        smColStart={2}
+        md={1}
+        lg={1}
+        lgColStart={11}
+        xl={2}
+        xlColStart={1}
+        itemNum={6}
+        align={GridItemAlign.left}
+      />
     </GridWrapper>
   </>
 );

--- a/src/components/GridItem/GridItem.stories.tsx
+++ b/src/components/GridItem/GridItem.stories.tsx
@@ -2,6 +2,7 @@ import { Meta } from '@storybook/react';
 import GridItem, { type GridItemProps } from './GridItem';
 import Grid from '../Grid/Grid';
 import { GridItemAlign } from './types';
+import { useEffect, useState } from 'react';
 
 const meta = {
   title: 'Components/Layouts/GridItem',
@@ -9,16 +10,78 @@ const meta = {
 } satisfies Meta<typeof GridItem>;
 
 export default meta;
+
+const longParagraph = (
+  <p>
+    Harry Phillips founded the auction house in 1796 in Westminster, London. Phillips gained international recognition
+    by selling paintings from the estate of Queen Marie Antoinette and household items from Napoleon Bonaparte, and it
+    remains the only auction house to have ever held a sale inside Buckingham Palace. Harry Phillips was an innovator
+    who combined business acumen with showmanship, introducing elaborate evening receptions before auctions – a standard
+    practice in the auction business today.
+  </p>
+);
+
+const getBreakpoint = () => {
+  const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => setViewportWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  if (viewportWidth <= 360) {
+    return 'xs';
+  }
+  if (viewportWidth <= 960) {
+    return 'sm';
+  }
+  if (viewportWidth <= 1400) {
+    return 'md';
+  }
+  if (viewportWidth <= 1800) {
+    return 'lg';
+  }
+  return 'xl';
+};
+
+const GridWrapper = ({ children }: { children: React.ReactNode }) => (
+  <>
+    <div style={{ textAlign: 'center', padding: '0.5rem', fontWeight: 600 }}>Breakpoint: {getBreakpoint()}</div>
+    <Grid style={{ backgroundColor: '#4444AA', padding: '1rem' }}>{children}</Grid>
+  </>
+);
+
+const getGridChild = (props: GridItemProps, i: number, gridContent?: React.ReactNode) => (
+  <GridItem
+    key={i}
+    style={{
+      backgroundColor: '#DDD',
+      padding: '1rem',
+      fontWeight: 500,
+      textAlign: 'center',
+    }}
+    {...props}
+  >
+    <div>{gridContent ?? `Grid Item ${i + 1}`}</div>
+  </GridItem>
+);
 export const Playground = ({ children, ...props }: GridItemProps) => (
-  <Grid>
-    <GridItem {...props} style={{ backgroundColor: 'gray' }}>
-      {children}
-    </GridItem>
-  </Grid>
+  <GridWrapper>
+    {Array.from({ length: 12 }).map((_, i) => (
+      <GridItem key={i} {...props} style={{ backgroundColor: 'gray' }}>
+        {getGridChild(props, i)}
+      </GridItem>
+    ))}
+  </GridWrapper>
 );
 
 Playground.args = {
-  children: <div>Grid Item</div>,
+  xs: 2,
+  sm: 1,
+  md: 2,
+  lg: 2,
+  align: GridItemAlign.left,
 };
 
 Playground.argTypes = {
@@ -31,41 +94,31 @@ Playground.argTypes = {
 };
 
 export const CenteredGridItem = (props: GridItemProps) => (
-  <Grid>
-    <GridItem style={{ backgroundColor: 'gray' }} {...props} align={GridItemAlign.center}>
-      <p>
-        Harry Phillips founded the auction house in 1796 in Westminster, London. Phillips gained international
-        recognition by selling paintings from the estate of Queen Marie Antoinette and household items from Napoleon
-        Bonaparte, and it remains the only auction house to have ever held a sale inside Buckingham Palace. Harry
-        Phillips was an innovator who combined business acumen with showmanship, introducing elaborate evening
-        receptions before auctions – a standard practice in the auction business today.
-      </p>
-    </GridItem>
-    <GridItem style={{ backgroundColor: 'gray' }} {...props} align={GridItemAlign.center}>
-      <p>
-        Harry Phillips founded the auction house in 1796 in Westminster, London. Phillips gained international
-        recognition by selling paintings from the estate of Queen Marie Antoinette and household items from Napoleon
-        Bonaparte, and it remains the only auction house to have ever held a sale inside Buckingham Palace. Harry
-        Phillips was an innovator who combined business acumen with showmanship, introducing elaborate evening
-        receptions before auctions – a standard practice in the auction business today.
-      </p>
-    </GridItem>
-  </Grid>
+  <GridWrapper>
+    {getGridChild(props, 0, longParagraph)}
+    {getGridChild(props, 1, longParagraph)}
+  </GridWrapper>
 );
 
 CenteredGridItem.args = {
   sm: 2,
-  md: 4,
-  lg: 8,
+  md: 3,
+  lg: 6,
+};
+
+CenteredGridItem.argTypes = {
+  align: {
+    options: GridItemAlign,
+    control: {
+      type: 'select',
+      options: [GridItemAlign.center],
+    },
+  },
 };
 
 export const LeftAndRightGridItems = () => (
-  <Grid>
-    <GridItem style={{ backgroundColor: 'gray' }} xs={1} sm={1} md={2} lg={4} align={GridItemAlign.left}>
-      <p>Left align</p>
-    </GridItem>
-    <GridItem style={{ backgroundColor: 'gray' }} xs={1} sm={1} md={4} lg={6} align={GridItemAlign.right}>
-      <p>Right align</p>
-    </GridItem>
-  </Grid>
+  <GridWrapper>
+    {getGridChild({ xs: 1, sm: 1, md: 2, lg: 4, align: GridItemAlign.left }, 0)}
+    {getGridChild({ xs: 1, sm: 1, md: 4, lg: 6, align: GridItemAlign.right }, 1)}
+  </GridWrapper>
 );

--- a/src/components/GridItem/GridItem.stories.tsx
+++ b/src/components/GridItem/GridItem.stories.tsx
@@ -45,16 +45,21 @@ const getBreakpoint = () => {
   return 'xl';
 };
 
-const GridWrapper = ({ children }: { children: React.ReactNode }) => (
-  <>
+const GridWrapper = ({ title = '', children }: { title?: string; children: React.ReactNode }) => (
+  <div style={{ marginTop: '2rem' }}>
+    {title ? <h2>{title}</h2> : null}
     <div style={{ textAlign: 'center', padding: '0.5rem', fontWeight: 600 }}>Breakpoint: {getBreakpoint()}</div>
     <Grid style={{ backgroundColor: '#4444AA', padding: '1rem' }}>{children}</Grid>
-  </>
+  </div>
 );
+type GridChildProps = {
+  itemNum: number;
+  gridContent?: React.ReactNode;
+} & GridItemProps;
 
-const getGridChild = (props: GridItemProps, i: number, gridContent?: React.ReactNode) => (
+const GridChild = ({ itemNum, gridContent, ...props }: GridChildProps) => (
   <GridItem
-    key={i}
+    key={itemNum}
     style={{
       backgroundColor: '#DDD',
       padding: '1rem',
@@ -63,14 +68,14 @@ const getGridChild = (props: GridItemProps, i: number, gridContent?: React.React
     }}
     {...props}
   >
-    <div>{gridContent ?? `Grid Item ${i + 1}`}</div>
+    <div>{gridContent ?? `Item ${itemNum}`}</div>
   </GridItem>
 );
 export const Playground = ({ children, ...props }: GridItemProps) => (
   <GridWrapper>
     {Array.from({ length: 12 }).map((_, i) => (
       <GridItem key={i} {...props} style={{ backgroundColor: 'gray' }}>
-        {getGridChild(props, i)}
+        <GridChild itemNum={i + 1} {...props} />
       </GridItem>
     ))}
   </GridWrapper>
@@ -95,8 +100,8 @@ Playground.argTypes = {
 
 export const CenteredGridItem = (props: GridItemProps) => (
   <GridWrapper>
-    {getGridChild(props, 0, longParagraph)}
-    {getGridChild(props, 1, longParagraph)}
+    <GridChild itemNum={1} gridContent={longParagraph} {...props} />
+    <GridChild itemNum={2} gridContent={longParagraph} {...props} />
   </GridWrapper>
 );
 
@@ -118,7 +123,37 @@ CenteredGridItem.argTypes = {
 
 export const LeftAndRightGridItems = () => (
   <GridWrapper>
-    {getGridChild({ xs: 1, sm: 1, md: 2, lg: 4, align: GridItemAlign.left }, 0)}
-    {getGridChild({ xs: 1, sm: 1, md: 4, lg: 6, align: GridItemAlign.right }, 1)}
+    <GridChild itemNum={1} sm={1} md={2} lg={4} align={GridItemAlign.left} />
+    <GridChild itemNum={2} sm={1} md={4} lg={6} align={GridItemAlign.right} />
   </GridWrapper>
+);
+
+export const GridWithOffsetColumns = () => (
+  <>
+    <GridWrapper title="1 Child (Offset layout)">
+      <GridChild
+        xsColStart={2}
+        sm={1}
+        smColStart={2}
+        md={3}
+        mdColStart={4}
+        lg={6}
+        lgColStart={7}
+        itemNum={1}
+        align={GridItemAlign.left}
+      />
+    </GridWrapper>
+    <GridWrapper title="2 Children (2 column layout)">
+      <GridChild xs={1} sm={1} md={2} mdColStart={1} lg={4} lgColStart={2} itemNum={1} align={GridItemAlign.left} />
+      <GridChild xs={1} sm={1} md={2} mdColStart={5} lg={4} lgColStart={8} itemNum={2} align={GridItemAlign.right} />
+    </GridWrapper>
+    <GridWrapper title="6 Children (Funky layout)">
+      <GridChild xs={2} sm={2} md={1} lg={1} lgColStart={2} itemNum={1} align={GridItemAlign.left} />
+      <GridChild xs={1} sm={1} smColStart={2} md={4} lg={1} lgColStart={4} itemNum={2} align={GridItemAlign.left} />
+      <GridChild xs={2} sm={2} md={1} lg={1} lgColStart={6} itemNum={3} align={GridItemAlign.left} />
+      <GridChild xs={1} sm={1} smColStart={2} md={1} lg={1} lgColStart={7} itemNum={4} align={GridItemAlign.left} />
+      <GridChild xs={2} sm={2} md={4} lg={1} lgColStart={9} itemNum={5} align={GridItemAlign.left} />
+      <GridChild xs={1} sm={1} smColStart={2} md={1} lg={1} lgColStart={11} itemNum={6} align={GridItemAlign.left} />
+    </GridWrapper>
+  </>
 );

--- a/src/components/GridItem/GridItem.tsx
+++ b/src/components/GridItem/GridItem.tsx
@@ -26,6 +26,9 @@ export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   lg?: number;
   /**
+   * Determines how many columns this GridItem spans at the xl breakpoint, defaults to the maximum of 12 columns.  If there are less than 2 columns in the Grid at the xl breakpoint they will be centered.
+   */
+  xl?: number;
    * Optional element to render as the top-level component e.g. 'div', 'span', CustomComponent, etc.  Defaults to 'div'.
    */
   element?: React.ElementType;
@@ -46,6 +49,7 @@ const GridItem = ({
   sm = 2,
   md = 6,
   lg = 12,
+  xl = 12,
   align = GridItemAlign.center,
   element: Element = 'div',
   className,
@@ -53,7 +57,7 @@ const GridItem = ({
 }: GridItemProps) => {
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'GridItem');
 
-  const columnSpansPerBreakpoint = useMemo(() => ({ xs, sm, md, lg }) as const, [xs, sm, md, lg]);
+  const columnSpansPerBreakpoint = useMemo(() => ({ xs, sm, md, lg, xl }) as const, [xs, sm, md, lg, xl]);
   const gridItemClasses = useMemo(() => {
     return [
       baseClassName, // figure out the class names for each breakpoint

--- a/src/components/GridItem/GridItem.tsx
+++ b/src/components/GridItem/GridItem.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { getCommonProps } from '../../utils';
 import classnames from 'classnames';
 import { determineColumnSpanClassName, validateColumnSpans } from './gridItemUtils';
-import { GridItemAlign } from './types';
+import { BreakpointKey, GridItemAlign } from './types';
 
 export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -29,6 +29,27 @@ export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
    * Determines how many columns this GridItem spans at the xl breakpoint, defaults to the maximum of 12 columns.  If there are less than 2 columns in the Grid at the xl breakpoint they will be centered.
    */
   xl?: number;
+  /**
+   * The starting column for this GridItem at the xs breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the xs breakpoint.
+   */
+  xsColStart?: number;
+  /**
+   * The starting column for this GridItem at the sm breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the sm breakpoint.
+   */
+  smColStart?: number;
+  /**
+   * The starting column for this GridItem at the md breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the md breakpoint.
+   */
+  mdColStart?: number;
+  /**
+   * The starting column for this GridItem at the lg breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the lg breakpoint.
+   */
+  lgColStart?: number;
+  /**
+   * The starting column for this GridItem at the xl breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the xl breakpoint.
+   */
+  xlColStart?: number;
+  /**
    * Optional element to render as the top-level component e.g. 'div', 'span', CustomComponent, etc.  Defaults to 'div'.
    */
   element?: React.ElementType;
@@ -50,6 +71,11 @@ const GridItem = ({
   md = 6,
   lg = 12,
   xl = 12,
+  xsColStart,
+  smColStart,
+  mdColStart,
+  lgColStart,
+  xlColStart,
   align = GridItemAlign.center,
   element: Element = 'div',
   className,
@@ -58,15 +84,25 @@ const GridItem = ({
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'GridItem');
 
   const columnSpansPerBreakpoint = useMemo(() => ({ xs, sm, md, lg, xl }) as const, [xs, sm, md, lg, xl]);
+  const columnStartsPerBreakpoint = useMemo(
+    () => ({ xs: xsColStart, sm: smColStart, md: mdColStart, lg: lgColStart, xl: xlColStart }),
+    [xsColStart, smColStart, mdColStart, lgColStart, xlColStart],
+  );
+
   const gridItemClasses = useMemo(() => {
     return [
       baseClassName, // figure out the class names for each breakpoint
       Object.entries(columnSpansPerBreakpoint).map(([key, value]) =>
-        determineColumnSpanClassName(key as GridItemAlign, value, align),
+        determineColumnSpanClassName(
+          key as BreakpointKey,
+          value,
+          columnStartsPerBreakpoint[key as BreakpointKey],
+          align,
+        ),
       ),
       className,
     ];
-  }, [align, columnSpansPerBreakpoint, baseClassName, className]);
+  }, [baseClassName, columnSpansPerBreakpoint, className, columnStartsPerBreakpoint, align]);
 
   if (!validateColumnSpans(Object.values(columnSpansPerBreakpoint))) {
     return null;

--- a/src/components/GridItem/GridItem.tsx
+++ b/src/components/GridItem/GridItem.tsx
@@ -92,14 +92,11 @@ const GridItem = ({
   const gridItemClasses = useMemo(() => {
     return [
       baseClassName, // figure out the class names for each breakpoint
-      Object.entries(columnSpansPerBreakpoint).map(([key, value]) =>
-        determineColumnSpanClassName(
-          key as BreakpointKey,
-          value,
-          columnStartsPerBreakpoint[key as BreakpointKey],
-          align,
-        ),
-      ),
+      Object.entries(columnSpansPerBreakpoint).map(([key, columnSpan]) => {
+        const columnStart = columnStartsPerBreakpoint[key as BreakpointKey];
+
+        return determineColumnSpanClassName(key as BreakpointKey, columnSpan, columnStart, align);
+      }),
       className,
     ];
   }, [baseClassName, columnSpansPerBreakpoint, className, columnStartsPerBreakpoint, align]);

--- a/src/components/GridItem/GridItem.tsx
+++ b/src/components/GridItem/GridItem.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
-import { getCommonProps } from '../../utils';
+import { BreakpointTokens, getCommonProps } from '../../utils';
 import classnames from 'classnames';
 import { determineColumnSpanClassName, validateColumnSpans } from './gridItemUtils';
-import { BreakpointKey, GridItemAlign } from './types';
+import { GridItemAlign } from './types';
 
 export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -93,9 +93,9 @@ const GridItem = ({
     return [
       baseClassName, // figure out the class names for each breakpoint
       Object.entries(columnSpansPerBreakpoint).map(([key, columnSpan]) => {
-        const columnStart = columnStartsPerBreakpoint[key as BreakpointKey];
+        const columnStart = columnStartsPerBreakpoint[key as BreakpointTokens];
 
-        return determineColumnSpanClassName(key as BreakpointKey, columnSpan, columnStart, align);
+        return determineColumnSpanClassName(key as BreakpointTokens, columnSpan, columnStart, align);
       }),
       className,
     ];

--- a/src/components/GridItem/GridItem.tsx
+++ b/src/components/GridItem/GridItem.tsx
@@ -10,11 +10,20 @@ export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   align?: GridItemAlign;
   /**
-   * column spans at different breakpoints, defaults to all columns.  If less than the total number of columns at the breakpoint it will be centered.
+   * Determines how many columns this GridItem spans at the xs breakpoint, defaults to the maximum of 2 columns.  If there are less than 2 columns in the Grid at the xs breakpoint it will be centered.
    */
   xs?: number;
+  /**
+   * Determines how many columns this GridItem spans at the sm breakpoint, defaults to the maximum of 2 columns.  If there are less than 2 columns in the Grid at the sm breakpoint it will be centered.
+   */
   sm?: number;
+  /**
+   * Determines how many columns this GridItem spans at the md breakpoint, defaults to the maximum of 6 columns.  If there are less than 6 columns in the Grid at the md breakpoint they will be centered.
+   */
   md?: number;
+  /**
+   * Determines how many columns this GridItem spans at the lg breakpoint, defaults to the maximum of 12 columns.  If there are less than 2 columns in the Grid at the lg breakpoint they will be centered.
+   */
   lg?: number;
   /**
    * Optional element to render as the top-level component e.g. 'div', 'span', CustomComponent, etc.  Defaults to 'div'.

--- a/src/components/GridItem/_gridItem.scss
+++ b/src/components/GridItem/_gridItem.scss
@@ -46,5 +46,11 @@
         @include gridItemColumnSpan($i, 12);
       }
     }
+  @include media($size-xl) {
+    @for $i from 1 through 12 {
+      &--span-xl-#{$i} {
+        @include gridItemColumnSpan($i, 12);
+      }
+    }
   }
 }

--- a/src/components/GridItem/_gridItem.scss
+++ b/src/components/GridItem/_gridItem.scss
@@ -2,7 +2,7 @@
 @use '#scss/allPartials' as *;
 
 @mixin gridItemColumnSpan($span: 1, $total-cols: 12) {
-  grid-column: span $span;
+  grid-column: auto / span $span;
 
   &-align-right {
     grid-column-end: $total-cols + 1;
@@ -24,10 +24,22 @@
     }
   }
 
+  @for $i from 1 through 6 {
+    &--start-xs-#{$i} {
+      grid-column-start: #{$i};
+    }
+  }
+
   @include media($size-sm) {
     @for $i from 1 through 2 {
       &--span-sm-#{$i} {
         @include gridItemColumnSpan($i, 2);
+      }
+    }
+
+    @for $i from 1 through 6 {
+      &--start-sm-#{$i} {
+        grid-column-start: #{$i};
       }
     }
   }
@@ -38,6 +50,12 @@
         @include gridItemColumnSpan($i, 6);
       }
     }
+
+    @for $i from 1 through 6 {
+      &--start-md-#{$i} {
+        grid-column-start: #{$i};
+      }
+    }
   }
 
   @include media($size-lg) {
@@ -46,10 +64,24 @@
         @include gridItemColumnSpan($i, 12);
       }
     }
+
+    @for $i from 1 through 12 {
+      &--start-lg-#{$i} {
+        grid-column-start: #{$i};
+      }
+    }
+  }
+
   @include media($size-xl) {
     @for $i from 1 through 12 {
       &--span-xl-#{$i} {
         @include gridItemColumnSpan($i, 12);
+      }
+    }
+
+    @for $i from 1 through 12 {
+      &--start-xl-#{$i} {
+        grid-column-start: #{$i};
       }
     }
   }

--- a/src/components/GridItem/gridItemUtils.ts
+++ b/src/components/GridItem/gridItemUtils.ts
@@ -1,13 +1,19 @@
 import { px } from '../../utils';
 import { GridItemProps } from './GridItem';
-import { GridItemAlign } from './types';
+import { BreakpointKey, GridItemAlign } from './types';
 
 export const determineColumnSpanClassName = (
-  breakpoint: GridItemAlign,
+  breakpoint: BreakpointKey,
   columnSpan: number,
+  columnStart?: number,
   align: GridItemProps['align'] = GridItemAlign.center,
 ): string => {
-  return `${px}-grid-item--span-${breakpoint}-${columnSpan} ${px}-grid-item--span-${breakpoint}-${columnSpan}-align-${align}`;
+  const colSpanClass = `${px}-grid-item--span-${breakpoint}-${columnSpan}`;
+  // If columnStart is set, default align (left) is always used
+  const colAlignClass = `${px}-grid-item--span-${breakpoint}-${columnSpan}-align-${columnStart ? GridItemAlign.left : align}`;
+  const colStartClass = columnStart ? `${px}-grid-item--start-${breakpoint}-${columnStart}` : '';
+
+  return `${colSpanClass} ${colAlignClass} ${colStartClass}`.replace(/\s+/g, ' ').trim();
 };
 
 export const validateColumnSpans = (columnSpans: number[]) => {

--- a/src/components/GridItem/gridItemUtils.ts
+++ b/src/components/GridItem/gridItemUtils.ts
@@ -1,9 +1,9 @@
-import { px } from '../../utils';
+import { BreakpointTokens, px } from '../../utils';
 import { GridItemProps } from './GridItem';
-import { BreakpointKey, GridItemAlign } from './types';
+import { GridItemAlign } from './types';
 
 export const determineColumnSpanClassName = (
-  breakpoint: BreakpointKey,
+  breakpoint: BreakpointTokens,
   columnSpan: number,
   columnStart?: number,
   align: GridItemProps['align'] = GridItemAlign.center,

--- a/src/components/GridItem/types.ts
+++ b/src/components/GridItem/types.ts
@@ -3,3 +3,10 @@ export enum GridItemAlign {
   left = 'left',
   right = 'right',
 }
+
+export enum BreakpointKey {
+  xs = 'xs',
+  sm = 'sm',
+  md = 'md',
+  lg = 'lg',
+}

--- a/src/components/GridItem/types.ts
+++ b/src/components/GridItem/types.ts
@@ -3,10 +3,3 @@ export enum GridItemAlign {
   left = 'left',
   right = 'right',
 }
-
-export enum BreakpointKey {
-  xs = 'xs',
-  sm = 'sm',
-  md = 'md',
-  lg = 'lg',
-}

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -34,6 +34,14 @@ export enum SpacingTokens {
   xxl = 'xxl',
 }
 
+export enum BreakpointTokens {
+  xs = 'xs',
+  sm = 'sm',
+  md = 'md',
+  lg = 'lg',
+  xl = 'xl',
+}
+
 /* eslint-disable @typescript-eslint/no-empty-function */
 export const noOp = () => {};
 


### PR DESCRIPTION
**Jira ticket**

[L3-6072](https://phillipsauctions.atlassian.net/browse/L3-6072)

**Summary**

When I started working on this ticket, I discovered that we didn't have a way to explicitly set `grid-column-start` for a `<GridItem />`, which meant we were unable to have empty columns in our layouts using the base `<Grid />` and `<GridItem />` components. There was some css we had in remix that was attempting to to fix the grid layout to achieve this, but it was being overwritten by the css coming from seldon.

To fix this, I added some props to GridItem (`*ColStart` for each breakpoint), and when they're used, it essentially just sets the `grid-column-start` value for that breakpoint.

I also added support for the `xl` breakpoint because we didn't previously have it and the design differed between the `lg` and `xl` breakpoints.

I also made a bunch of tweaks to the GridItem stories that should hopefully make things a little clearer in regards to how it all works together

**Screenshots**
New story that shows the possibilities. These were all done using *colStart props:
#### xs:
![Screenshot 2025-03-21 172230](https://github.com/user-attachments/assets/473671d4-f462-4812-993a-bf9395e51bf9)
---
#### sm:
![image](https://github.com/user-attachments/assets/45b8ad12-c1fd-420f-b9da-5734ea2f039c)
---
#### md:
![Screenshot 2025-03-21 171637](https://github.com/user-attachments/assets/286ed54e-0ce1-4954-9757-930f2e8adaad)
---
#### lg:
![Screenshot 2025-03-21 172415](https://github.com/user-attachments/assets/190bed6f-171f-4589-9e69-61edcfac8ff2)
---
#### xl:
![Screenshot 2025-03-21 173122](https://github.com/user-attachments/assets/53ac61e0-4871-448a-a084-867e782d9e74)


**Figma link**

[Figma Link](https://www.figma.com/file/FIGMA-LINK)



**Change List (describe the changes made to the files)**

- Additions, Changes, and Removals. 
This pull request includes significant changes to the `GridItem` component and its related files to enhance its functionality and flexibility. The most important changes include the addition of new properties for specifying column start positions at different breakpoints, updates to the storybook stories, and modifications to the SCSS styles to support the new features.

Enhancements to `GridItem` component:

* [`src/components/GridItem/GridItem.tsx`](diffhunk://#diff-89fdde54c30cd7583443e860e25e88f97cf7bb2865a11072acbfd207fca42b71L5-R51): Added new properties (`xsColStart`, `smColStart`, `mdColStart`, `lgColStart`, `xlColStart`) to specify the starting column for the `GridItem` at different breakpoints. [[1]](diffhunk://#diff-89fdde54c30cd7583443e860e25e88f97cf7bb2865a11072acbfd207fca42b71L5-R51) [[2]](diffhunk://#diff-89fdde54c30cd7583443e860e25e88f97cf7bb2865a11072acbfd207fca42b71R73-R105)
* [`src/components/GridItem/gridItemUtils.ts`](diffhunk://#diff-175d18007f6f6f68da6a7a4f4566c80aef36680d46b8edc5dae637e7ed4c897aL3-R16): Updated the `determineColumnSpanClassName` function to handle the new column start properties.
* [`src/components/GridItem/types.ts`](diffhunk://#diff-95d5d62117f25ca5ff229d908992721c271f16a09700e776e36272901438d2a7R6-R12): Added a new `BreakpointKey` enum to represent the different breakpoints.

Updates to storybook stories:

* [`src/components/GridItem/GridItem.stories.tsx`](diffhunk://#diff-4cded9f45946bd07bd910304c7049ce30163e86d977c0d818c735754e0b39d18R5-R89): Refactored the stories to use the new `GridWrapper` and `GridChild` components, and added new stories to demonstrate the usage of the column start properties. [[1]](diffhunk://#diff-4cded9f45946bd07bd910304c7049ce30163e86d977c0d818c735754e0b39d18R5-R89) [[2]](diffhunk://#diff-4cded9f45946bd07bd910304c7049ce30163e86d977c0d818c735754e0b39d18L34-R158)

SCSS modifications:

* [`src/components/GridItem/_gridItem.scss`](diffhunk://#diff-4ca2779ef97d0816dfd9a6c57d68d56c8a2bc976f64cab290911409095325fa7L5-R5): Updated the styles to support the new column start properties, including adding new class definitions for each breakpoint. [[1]](diffhunk://#diff-4ca2779ef97d0816dfd9a6c57d68d56c8a2bc976f64cab290911409095325fa7L5-R5) [[2]](diffhunk://#diff-4ca2779ef97d0816dfd9a6c57d68d56c8a2bc976f64cab290911409095325fa7R27-R44) [[3]](diffhunk://#diff-4ca2779ef97d0816dfd9a6c57d68d56c8a2bc976f64cab290911409095325fa7R53-R58) [[4]](diffhunk://#diff-4ca2779ef97d0816dfd9a6c57d68d56c8a2bc976f64cab290911409095325fa7R67-R86)

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-6072]: https://phillipsauctions.atlassian.net/browse/L3-6072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ