### PR TITLE
fix(upgrade): L3-6222 allow seldon to be used with phillips-public older React 18 version

### DIFF
--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -93,12 +93,12 @@ export const CarouselWithDots = (props: CarouselProps & CarouselDotsProps) => (
         </CarouselItem>
       ))}
     </CarouselContent>
-    <CarouselDots maxDots={props.maxDots} position={props.position} numberOfSlides={9} />
+    <CarouselDots maxDots={props.maxDots} position={props.position} numberOfSlides={9} id={props.id} />
   </Carousel>
 );
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-CarouselWithDots.args = { maxDots: 9 } satisfies CarouselProps & CarouselDotsProps;
+CarouselWithDots.args = { maxDots: 9, id: 'carousel-dots' } satisfies CarouselProps & CarouselDotsProps;
 
 CarouselWithDots.argTypes = {};
 
@@ -123,13 +123,13 @@ export const CarouselWithDotsAndArrows = (props: CarouselProps & CarouselDotsPro
         </CarouselItem>
       ))}
     </CarouselContent>
-    <CarouselDots maxDots={props.maxDots} position={props.position} numberOfSlides={9} />
+    <CarouselDots maxDots={props.maxDots} position={props.position} numberOfSlides={9} id={props.id} />
     <CarouselArrows />
   </Carousel>
 );
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-CarouselWithDotsAndArrows.args = { maxDots: 9 } satisfies CarouselProps & CarouselDotsProps;
+CarouselWithDotsAndArrows.args = { maxDots: 9, id: 'carousel-dots-arrows' } satisfies CarouselProps & CarouselDotsProps;
 
 CarouselWithDotsAndArrows.argTypes = {};
 
@@ -154,12 +154,13 @@ export const CarouselWithDotsOverflow = (props: CarouselProps & CarouselDotsProp
         </CarouselItem>
       ))}
     </CarouselContent>
-    <CarouselDots maxDots={props.maxDots} position={props.position} numberOfSlides={20} />
+    <CarouselDots maxDots={props.maxDots} position={props.position} numberOfSlides={20} id={props.id} />
   </Carousel>
 );
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-CarouselWithDotsOverflow.args = { maxDots: 9 } satisfies CarouselProps & CarouselDotsProps;
+CarouselWithDotsOverflow.args = { maxDots: 9, id: 'carousel-dots-overflow' } satisfies CarouselProps &
+  CarouselDotsProps;
 
 CarouselWithDotsOverflow.argTypes = {};
 
@@ -187,12 +188,12 @@ export const ControlledCarousel = (props: CarouselProps & CarouselDotsProps) => 
           </CarouselItem>
         ))}
       </CarouselContent>
-      <CarouselDots maxDots={props.maxDots} position={props.position} numberOfSlides={9} />
+      <CarouselDots maxDots={props.maxDots} position={props.position} numberOfSlides={9} id={props.id} />
     </Carousel>
   );
 };
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
-CarouselWithDots.args = {} satisfies CarouselProps & CarouselDotsProps;
+CarouselWithDots.args = { id: 'carousel-dots' } satisfies CarouselProps & CarouselDotsProps;
 
 CarouselWithDots.argTypes = {};

--- a/src/components/Carousel/Carousel.test.tsx
+++ b/src/components/Carousel/Carousel.test.tsx
@@ -15,7 +15,7 @@ describe('Carousel', () => {
           <CarouselItem>Slide 2</CarouselItem>
           <CarouselItem>Slide 3</CarouselItem>
         </CarouselContent>
-        <CarouselDots />
+        <CarouselDots id="test-carousel-dots" />
       </Carousel>,
     );
     expect(screen.getByText('Slide 1')).toBeInTheDocument();

--- a/src/components/Carousel/CarouselDots.tsx
+++ b/src/components/Carousel/CarouselDots.tsx
@@ -7,7 +7,7 @@ import { CarouselDot } from './CarouselDot';
 
 export interface CarouselDotsProps extends ComponentProps<'div'> {
   /**
-   * A custom `id` for the `<CarouselDots>`
+   * A unique `id` for the `<CarouselDots>`
    */
   id: string;
   /**

--- a/src/components/Carousel/CarouselDots.tsx
+++ b/src/components/Carousel/CarouselDots.tsx
@@ -38,8 +38,8 @@ const dotGap = 12;
 const centerDotContainer = (dotWidth + dotGap) / 2;
 
 const CarouselDots = forwardRef<HTMLDivElement, CarouselDotsProps>(
-  ({ className, maxDots = 9, position = 'inline', numberOfSlides = 0, ...props }, ref) => {
-    const { className: baseClassName, ...commonProps } = getCommonProps(props, 'CarouselDots');
+  ({ className, maxDots = 9, position = 'inline', numberOfSlides = 0, id, ...props }, ref) => {
+    const { className: baseClassName, ...commonProps } = getCommonProps({ id, ...props }, 'CarouselDots');
     const { api, onSlideChange } = useCarousel();
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [scrollSnaps, setScrollSnaps] = useState<number[]>(
@@ -138,7 +138,7 @@ const CarouselDots = forwardRef<HTMLDivElement, CarouselDotsProps>(
 
               return (
                 <CarouselDot
-                  key={`${props?.id}-dot-${index}`}
+                  key={`${id}-dot-${index}`}
                   onClick={() => onDotButtonClick(index)}
                   isSelected={isSelected}
                   scrollableContainerRef={scrollableContainerRef}

--- a/src/components/Carousel/CarouselDots.tsx
+++ b/src/components/Carousel/CarouselDots.tsx
@@ -40,7 +40,6 @@ const centerDotContainer = (dotWidth + dotGap) / 2;
 const CarouselDots = forwardRef<HTMLDivElement, CarouselDotsProps>(
   ({ className, maxDots = 9, position = 'inline', numberOfSlides = 0, ...props }, ref) => {
     const { className: baseClassName, ...commonProps } = getCommonProps(props, 'CarouselDots');
-    const { id } = props;
     const { api, onSlideChange } = useCarousel();
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [scrollSnaps, setScrollSnaps] = useState<number[]>(
@@ -139,7 +138,7 @@ const CarouselDots = forwardRef<HTMLDivElement, CarouselDotsProps>(
 
               return (
                 <CarouselDot
-                  key={`${id}-dot-${index}`}
+                  key={`${props?.id}-dot-${index}`}
                   onClick={() => onDotButtonClick(index)}
                   isSelected={isSelected}
                   scrollableContainerRef={scrollableContainerRef}

--- a/src/components/Carousel/CarouselDots.tsx
+++ b/src/components/Carousel/CarouselDots.tsx
@@ -1,9 +1,10 @@
 import classNames from 'classnames';
 import { EmblaCarouselType } from 'embla-carousel';
-import { ComponentProps, forwardRef, useCallback, useEffect, useState, useId, useRef, useMemo } from 'react';
+import { ComponentProps, forwardRef, useCallback, useEffect, useState, useRef, useMemo } from 'react';
 import { useCarousel } from './utils';
 import { getCommonProps } from '../../utils';
 import { CarouselDot } from './CarouselDot';
+import { generateUniqueId } from '../../utils/constants';
 
 export interface CarouselDotsProps extends ComponentProps<'div'> {
   /**
@@ -36,7 +37,7 @@ const centerDotContainer = (dotWidth + dotGap) / 2;
 const CarouselDots = forwardRef<HTMLDivElement, CarouselDotsProps>(
   ({ className, maxDots = 9, position = 'inline', numberOfSlides = 0, ...props }, ref) => {
     const { className: baseClassName, ...commonProps } = getCommonProps(props, 'CarouselDots');
-    const componentId = useId();
+    const componentId = useRef(generateUniqueId()).current;
     const { api, onSlideChange } = useCarousel();
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [scrollSnaps, setScrollSnaps] = useState<number[]>(

--- a/src/components/Carousel/CarouselDots.tsx
+++ b/src/components/Carousel/CarouselDots.tsx
@@ -40,7 +40,7 @@ const centerDotContainer = (dotWidth + dotGap) / 2;
 const CarouselDots = forwardRef<HTMLDivElement, CarouselDotsProps>(
   ({ className, maxDots = 9, position = 'inline', numberOfSlides = 0, ...props }, ref) => {
     const { className: baseClassName, ...commonProps } = getCommonProps(props, 'CarouselDots');
-    const componentId = useRef(props.id).current;
+    const { id } = props;
     const { api, onSlideChange } = useCarousel();
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [scrollSnaps, setScrollSnaps] = useState<number[]>(
@@ -139,7 +139,7 @@ const CarouselDots = forwardRef<HTMLDivElement, CarouselDotsProps>(
 
               return (
                 <CarouselDot
-                  key={`${componentId}-dot-${index}`}
+                  key={`${id}-dot-${index}`}
                   onClick={() => onDotButtonClick(index)}
                   isSelected={isSelected}
                   scrollableContainerRef={scrollableContainerRef}

--- a/src/components/Carousel/CarouselDots.tsx
+++ b/src/components/Carousel/CarouselDots.tsx
@@ -4,9 +4,12 @@ import { ComponentProps, forwardRef, useCallback, useEffect, useState, useRef, u
 import { useCarousel } from './utils';
 import { getCommonProps } from '../../utils';
 import { CarouselDot } from './CarouselDot';
-import { generateUniqueId } from '../../utils/constants';
 
 export interface CarouselDotsProps extends ComponentProps<'div'> {
+  /**
+   * A custom `id` for the `<CarouselDots>`
+   */
+  id: string;
   /**
    * The maximum number of dots to display.
    */
@@ -37,7 +40,7 @@ const centerDotContainer = (dotWidth + dotGap) / 2;
 const CarouselDots = forwardRef<HTMLDivElement, CarouselDotsProps>(
   ({ className, maxDots = 9, position = 'inline', numberOfSlides = 0, ...props }, ref) => {
     const { className: baseClassName, ...commonProps } = getCommonProps(props, 'CarouselDots');
-    const componentId = useRef(generateUniqueId()).current;
+    const componentId = useRef(props.id).current;
     const { api, onSlideChange } = useCarousel();
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [scrollSnaps, setScrollSnaps] = useState<number[]>(

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -59,11 +59,7 @@ describe('A DatePicker', () => {
     await userEvent.type(input, '{backspace}6');
     await waitFor(() => expect((input as HTMLInputElement).value).toEqual('2023-06-01 to 2023-06-06'));
     await userEvent.tab();
-    expect(mockedOnChange).toHaveBeenCalledWith(
-      [new Date('2023-06-01T05:00:00.000Z'), new Date('2023-06-06T05:00:00.000Z')],
-      '2023-06-01 to 2023-06-06',
-      expect.anything(),
-    );
+    expect(mockedOnChange).toHaveBeenCalledWith(expect.anything(), '2023-06-01 to 2023-06-06', expect.anything());
   });
 
   it('will revert to old value if user input is not a valid date', async () => {

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -58,8 +58,12 @@ describe('A DatePicker', () => {
     await userEvent.click(input);
     await userEvent.type(input, '{backspace}6');
     await waitFor(() => expect((input as HTMLInputElement).value).toEqual('2023-06-01 to 2023-06-06'));
-    await userEvent.click(document.body);
-    expect(mockedOnChange.mock.calls).toHaveLength(1);
+    await userEvent.tab();
+    expect(mockedOnChange).toHaveBeenCalledWith(
+      [new Date('2023-06-01T05:00:00.000Z'), new Date('2023-06-06T05:00:00.000Z')],
+      '2023-06-01 to 2023-06-06',
+      expect.anything(),
+    );
   });
 
   it('will revert to old value if user input is not a valid date', async () => {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -33,7 +33,7 @@ export interface DatePickerProps extends Omit<InputProps, 'defaultValue' | 'onCh
   hideLabel?: boolean;
 
   /**
-   * A custom `id` for the `<input>`
+   * A unique `id` for the `<input>`
    */
   id: string;
 

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -35,7 +35,11 @@ export const Playground = (props: DrawerProps) => {
 
       <PlaygroundSplitPanel />
       <Drawer isOpen={props.isOpen} onClose={onClose}>
-        <Subscribe autoFocus blurb="Receive exclusive content about our auctions, exhibitions, and special events." />
+        <Subscribe
+          id="subscribe-drawer"
+          autoFocus
+          blurb="Receive exclusive content about our auctions, exhibitions, and special events."
+        />
       </Drawer>
     </>
   );

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -177,7 +177,7 @@ const Input = React.forwardRef(
           className={classnames(`${px}-input__input`, className, {
             [`${px}-skeleton`]: isSkeletonLoading,
           })}
-          data-testid={`${id}-input`}
+          data-testid={id}
           disabled={inputProps.disabled}
           id={id}
           onChange={onChange}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import { generateUniqueId } from '../../utils/constants';
 import { px, useNormalizedInputProps } from '../../utils';
 
 export interface InputProps extends Omit<React.ComponentProps<'input'>, 'size'> {
@@ -29,7 +28,7 @@ export interface InputProps extends Omit<React.ComponentProps<'input'>, 'size'> 
   /**
    * A custom `id` for the `<input>`
    */
-  id?: string;
+  id: string;
 
   /**
    * Boolean to dictate whether input is inline with the label or not. `true` to use the inline version.
@@ -142,10 +141,9 @@ const Input = React.forwardRef(
     }: InputProps,
     ref: React.ForwardedRef<HTMLInputElement>,
   ) => {
-    const generatedId = React.useRef<string>(generateUniqueId()).current;
     const inputProps = useNormalizedInputProps({
       disabled,
-      id: id || generatedId,
+      id,
       invalid,
       invalidText,
       readOnly,
@@ -166,8 +164,8 @@ const Input = React.forwardRef(
     return (
       <div className={wrapperClassnames}>
         <label
-          data-testid={`label-${id || generatedId}`}
-          htmlFor={id || generatedId}
+          data-testid={`label-${id}`}
+          htmlFor={id}
           className={classnames(`${px}-input__label`, {
             [`${px}-input__label--hidden`]: hideLabel,
             [`${px}-skeleton`]: isSkeletonLoading,
@@ -181,7 +179,7 @@ const Input = React.forwardRef(
           })}
           data-testid={id}
           disabled={inputProps.disabled}
-          id={id || generatedId}
+          id={id}
           onChange={onChange}
           onClick={onClick}
           placeholder={isSkeletonLoading ? '' : placeholder}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -26,9 +26,9 @@ export interface InputProps extends Omit<React.ComponentProps<'input'>, 'size'> 
   hideLabel?: boolean;
 
   /**
-   * A custom `id` for the `<input>`
+   * A unique `id` for the `<input>`
    */
-  id?: string;
+  id: string;
 
   /**
    * Boolean to dictate whether input is inline with the label or not. `true` to use the inline version.
@@ -122,7 +122,7 @@ const Input = React.forwardRef(
       defaultValue,
       disabled,
       hideLabel,
-      id = '',
+      id,
       inline,
       invalid,
       invalidText,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
-
+import { generateUniqueId } from '../../utils/constants';
 import { px, useNormalizedInputProps } from '../../utils';
 
 export interface InputProps extends Omit<React.ComponentProps<'input'>, 'size'> {
@@ -142,7 +142,7 @@ const Input = React.forwardRef(
     }: InputProps,
     ref: React.ForwardedRef<HTMLInputElement>,
   ) => {
-    const generatedId = React.useId();
+    const generatedId = React.useRef<string>(generateUniqueId()).current;
     const inputProps = useNormalizedInputProps({
       disabled,
       id: id || generatedId,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -28,7 +28,7 @@ export interface InputProps extends Omit<React.ComponentProps<'input'>, 'size'> 
   /**
    * A custom `id` for the `<input>`
    */
-  id: string;
+  id?: string;
 
   /**
    * Boolean to dictate whether input is inline with the label or not. `true` to use the inline version.
@@ -122,7 +122,7 @@ const Input = React.forwardRef(
       defaultValue,
       disabled,
       hideLabel,
-      id,
+      id = '',
       inline,
       invalid,
       invalidText,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -177,7 +177,7 @@ const Input = React.forwardRef(
           className={classnames(`${px}-input__input`, className, {
             [`${px}-skeleton`]: isSkeletonLoading,
           })}
-          data-testid={id}
+          data-testid={`${id}-input`}
           disabled={inputProps.disabled}
           id={id}
           onChange={onChange}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -164,6 +164,7 @@ const Pagination = ({
         labelText={selectLabel}
         disabled={isDisabled}
         showIcon={false}
+        id={`${id}-select-button`}
       >
         {options.map((option) => {
           const optionValue = determineOptionValue(option);

--- a/src/components/PinchZoom/PinchZoom.stories.tsx
+++ b/src/components/PinchZoom/PinchZoom.stories.tsx
@@ -127,7 +127,7 @@ export const ZoomCarousel = () => {
           </PinchZoom>
         </CarouselItem>
       </CarouselContent>
-      <CarouselDots numberOfSlides={3} />
+      <CarouselDots id="zoom-carousel-dots" numberOfSlides={3} />
     </Carousel>
   );
 };
@@ -217,7 +217,7 @@ export const CarouselWithZoomModal = () => {
                 </CarouselItem>
               ))}
             </CarouselContent>
-            <CarouselDots numberOfSlides={images.length} position="on-content" />
+            <CarouselDots id="carousel-dots-on-content" numberOfSlides={images.length} position="on-content" />
           </Carousel>
         </Modal>
       )}
@@ -242,7 +242,7 @@ export const CarouselWithZoomModal = () => {
             </CarouselItem>
           ))}
         </CarouselContent>
-        <CarouselDots numberOfSlides={images.length} />
+        <CarouselDots id="carousel-dots" numberOfSlides={images.length} />
       </Carousel>
     </div>
   );

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -12,7 +12,7 @@ export interface SelectProps extends Merge<InputProps, React.ComponentProps<'sel
    */
   children: React.ReactNode;
   /**
-   * A custom `id` for the `<Select>`
+   * A unique `id` for the `<Select>`
    */
   id: string;
   /**

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import { px, useNormalizedInputProps } from '../../utils';
 import { InputProps } from '../Input/Input';
 import { Merge } from 'type-fest';
-import { generateUniqueId } from '../../utils/constants';
 import { SelectVariants } from './types';
 import ChevronDownIcon from '../../assets/chevronDown.svg?react';
 
@@ -12,6 +11,10 @@ export interface SelectProps extends Merge<InputProps, React.ComponentProps<'sel
    * Option elements that are selectable
    */
   children: React.ReactNode;
+  /**
+   * A custom `id` for the `<Select>`
+   */
+  id: string;
   /**
    * Determines if you want to show the icon
    */
@@ -59,10 +62,9 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     ref,
   ) => {
     const type = 'select';
-    const generatedId = React.useRef<string>(generateUniqueId()).current;
     const inputProps = useNormalizedInputProps({
       disabled,
-      id: id ?? generatedId,
+      id,
       invalid,
       invalidText,
       readOnly,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import { px, useNormalizedInputProps } from '../../utils';
 import { InputProps } from '../Input/Input';
 import { Merge } from 'type-fest';
-
+import { generateUniqueId } from '../../utils/constants';
 import { SelectVariants } from './types';
 import ChevronDownIcon from '../../assets/chevronDown.svg?react';
 
@@ -59,7 +59,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     ref,
   ) => {
     const type = 'select';
-    const generatedId = React.useId();
+    const generatedId = React.useRef<string>(generateUniqueId()).current;
     const inputProps = useNormalizedInputProps({
       disabled,
       id: id ?? generatedId,

--- a/src/patterns/Subscribe/Subscribe.test.tsx
+++ b/src/patterns/Subscribe/Subscribe.test.tsx
@@ -14,16 +14,17 @@ describe('Subscribe', () => {
   });
 
   it('it will render a blurb if one is passed in', () => {
-    render(<Subscribe title="Subscribe to Email" blurb="This blurb will be rendered" />);
+    render(<Subscribe id="test-id" title="Subscribe to Email" blurb="This blurb will be rendered" />);
     expect(screen.getByText(/This blurb will be rendered/)).toBeInTheDocument();
   });
   it('it will render a loading if subscriptionState=loading', () => {
-    render(<Subscribe title="Subscribe to Email" subscriptionState={SubscriptionState.Loading} />);
+    render(<Subscribe id="test-loading" title="Subscribe to Email" subscriptionState={SubscriptionState.Loading} />);
     expect(screen.getByText(/Loading.../)).toBeInTheDocument();
   });
   it('it will render an error if subscriptionState=invalid and invalidText passed', () => {
     render(
       <Subscribe
+        id="test-invalid"
         title="Subscribe to Email"
         subscriptionState={SubscriptionState.Invalid}
         invalidText="Invalid input"
@@ -33,13 +34,23 @@ describe('Subscribe', () => {
   });
   it('it will render an error if subscriptionState=error and errorText passed', () => {
     render(
-      <Subscribe title="Subscribe to Email" subscriptionState={SubscriptionState.Error} errorText="Network error" />,
+      <Subscribe
+        id="test-error"
+        title="Subscribe to Email"
+        subscriptionState={SubscriptionState.Error}
+        errorText="Network error"
+      />,
     );
     expect(screen.getByText(/Network error/)).toBeInTheDocument();
   });
   it('it will render an success text if subscriptionState=success', () => {
     render(
-      <Subscribe title="Subscribe to Email" subscriptionState={SubscriptionState.Success} successText="Success" />,
+      <Subscribe
+        id="test-success"
+        title="Subscribe to Email"
+        subscriptionState={SubscriptionState.Success}
+        successText="Success"
+      />,
     );
     expect(screen.getByText(/Success/)).toBeInTheDocument();
   });
@@ -54,6 +65,7 @@ describe('Subscribe', () => {
     });
     render(
       <Subscribe
+        id="test-submit"
         title="Subscribe to Email"
         blurb="This blurb will be rendered"
         buttonProps={{ onClick: mockCallback }}

--- a/src/patterns/Subscribe/Subscribe.tsx
+++ b/src/patterns/Subscribe/Subscribe.tsx
@@ -24,7 +24,7 @@ export interface SubscribeProps extends React.HTMLAttributes<HTMLFormElement> {
    */
   element?: React.ElementType<SubscribeProps>;
   /**
-   * A custom `id` for the `<Subscribe>`
+   * A unique `id` for the `<Subscribe>`
    */
   id: string;
   /**

--- a/src/patterns/Subscribe/Subscribe.tsx
+++ b/src/patterns/Subscribe/Subscribe.tsx
@@ -24,6 +24,10 @@ export interface SubscribeProps extends React.HTMLAttributes<HTMLFormElement> {
    */
   element?: React.ElementType<SubscribeProps>;
   /**
+   * A custom `id` for the `<Subscribe>`
+   */
+  id: string;
+  /**
    * Subscribe input label
    */
   inputLabelText?: string;
@@ -124,7 +128,7 @@ const Subscribe = ({
         warn={warn}
         warnText={text}
         required
-        id={`${title}-subscribe-input`}
+        id={props.id}
       />
       <Button
         className={`${baseClassName}__button ${className}`}

--- a/src/patterns/Subscribe/Subscribe.tsx
+++ b/src/patterns/Subscribe/Subscribe.tsx
@@ -124,6 +124,7 @@ const Subscribe = ({
         warn={warn}
         warnText={text}
         required
+        id={`${title}-subscribe-input`}
       />
       <Button
         className={`${baseClassName}__button ${className}`}

--- a/src/patterns/Subscribe/Subscribe.tsx
+++ b/src/patterns/Subscribe/Subscribe.tsx
@@ -91,9 +91,10 @@ const Subscribe = ({
   successText,
   privacyText = 'By signing up, you agree to receive email communications from Phillips.',
   subscriptionState = SubscriptionState.Default,
+  id,
   ...props
 }: SubscribeProps) => {
-  const { className: baseClassName, ...commonProps } = getCommonProps(props, 'Subscribe');
+  const { className: baseClassName, ...commonProps } = getCommonProps({ id, ...props }, 'Subscribe');
   const isInvalid = subscriptionState === SubscriptionState.Invalid;
   const isLoading = subscriptionState === SubscriptionState.Loading;
   const isSuccess = subscriptionState === SubscriptionState.Success;
@@ -111,7 +112,7 @@ const Subscribe = ({
   const invalid = isInvalid || isError;
 
   return (
-    <Element {...commonProps} className={classnames(baseClassName, className)} noValidate {...props}>
+    <Element id={id} {...commonProps} className={classnames(baseClassName, className)} noValidate {...props}>
       <h3 className={`${baseClassName}__title`}>{title}</h3>
       {blurb ? <p className={`${baseClassName}__blurb`}>{blurb}</p> : null}
 
@@ -127,7 +128,7 @@ const Subscribe = ({
         warn={warn}
         warnText={text}
         required
-        id={`${props?.id}-input`}
+        id={`${id}-input`}
       />
       <Button
         className={`${baseClassName}__button ${className}`}

--- a/src/patterns/Subscribe/Subscribe.tsx
+++ b/src/patterns/Subscribe/Subscribe.tsx
@@ -128,7 +128,7 @@ const Subscribe = ({
         warn={warn}
         warnText={text}
         required
-        id={props.id}
+        id={`${props.id}-input`}
       />
       <Button
         className={`${baseClassName}__button ${className}`}

--- a/src/patterns/Subscribe/Subscribe.tsx
+++ b/src/patterns/Subscribe/Subscribe.tsx
@@ -94,7 +94,7 @@ const Subscribe = ({
   ...props
 }: SubscribeProps) => {
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'Subscribe');
-
+  const { id } = props;
   const isInvalid = subscriptionState === SubscriptionState.Invalid;
   const isLoading = subscriptionState === SubscriptionState.Loading;
   const isSuccess = subscriptionState === SubscriptionState.Success;
@@ -128,7 +128,7 @@ const Subscribe = ({
         warn={warn}
         warnText={text}
         required
-        id={`${props.id}-input`}
+        id={`${id}-input`}
       />
       <Button
         className={`${baseClassName}__button ${className}`}

--- a/src/patterns/Subscribe/Subscribe.tsx
+++ b/src/patterns/Subscribe/Subscribe.tsx
@@ -94,7 +94,6 @@ const Subscribe = ({
   ...props
 }: SubscribeProps) => {
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'Subscribe');
-  const { id } = props;
   const isInvalid = subscriptionState === SubscriptionState.Invalid;
   const isLoading = subscriptionState === SubscriptionState.Loading;
   const isSuccess = subscriptionState === SubscriptionState.Success;
@@ -128,7 +127,7 @@ const Subscribe = ({
         warn={warn}
         warnText={text}
         required
-        id={`${id}-input`}
+        id={`${props?.id}-input`}
       />
       <Button
         className={`${baseClassName}__button ${className}`}

--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -103,10 +103,9 @@ $snwHeaderLink: 'snwHeaderLink';
 $snwFlyoutLink: 'snwFlyoutLink';
 $snwHeadingHero1: 'snwHeadingHero1';
 $snwHeadingHero2: 'snwHeadingHero2';
-$text-tokens:
-  $button, $link, $email, $label, $badge, $blockquote, $heading1, $heading2, $heading3, $heading4, $heading5, $title1,
-  $title2, $title3, $title4, $body1, $body2, $body3, $string1, $string2, $string3, $snwFlyoutLink, $snwHeaderLink,
-  $snwHeadingHero1, $snwHeadingHero2;
+$text-tokens: $button, $link, $email, $label, $badge, $blockquote, $heading1, $heading2, $heading3, $heading4, $heading5,
+  $title1, $title2, $title3, $title4, $body1, $body2, $body3, $string1, $string2, $string3, $snwFlyoutLink,
+  $snwHeaderLink, $snwHeadingHero1, $snwHeadingHero2;
 
 ////////////////////////
 /// Breakpoint TOKENS to be used for min-width comparisons, make sure they match BREAKPOINTS in constants.ts

--- a/src/site-furniture/Footer/Footer.test.tsx
+++ b/src/site-furniture/Footer/Footer.test.tsx
@@ -77,7 +77,7 @@ describe('Footer', () => {
 
   it('renders the components we pass to it', () => {
     render(<Footer {...commonProps} />);
-    expect(screen.queryByTestId(/subscribe/)).toBeInTheDocument();
+    expect(screen.queryByTestId('subscribe-subscribe')).toBeInTheDocument();
     expect(screen.queryByTestId(/social/)).toBeInTheDocument();
   });
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,3 +10,7 @@ export const BREAKPOINTS = {
 };
 
 export const DEFAULT_REM_SIZE = 16;
+
+export const generateUniqueId = () => {
+  return `id-${Math.random().toString(36).slice(2, 11)}`;
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,7 +10,3 @@ export const BREAKPOINTS = {
 };
 
 export const DEFAULT_REM_SIZE = 16;
-
-export const generateUniqueId = () => {
-  return `id-${Math.random().toString(36).slice(2, 11)}`;
-};

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -43,7 +43,7 @@ export interface InputProps {
    */
   disabled?: boolean;
   /**
-   * Specify a custom `id` for the `<input>`
+   * Specify a unique `id` for the `<input>`
    */
   id: string;
   /**


### PR DESCRIPTION
**Jira ticket**

[L3-6222](https://phillipsauctions.atlassian.net/browse/L3-6222)

**Screenshots**

https://github.com/user-attachments/assets/9631d0bb-cd2d-4ded-ae1f-6759a44c30c0

**Figma link**

[Figma Link](https://www.figma.com/file/FIGMA-LINK)

**Summary**

Removed all `useId` from Seldon, make `id` required field. 

The newest version of Seldon is crashing on phillips-public
This crash happens because the React version in the Razor Phillips-public is not v18.3 it does not support the v18.3 React.useId()
https://www.nuget.org/packages/React.AspNet/

At first I tried to use UUID but that didn’t work either because the server-side rendering environment does not support the Web Crypto API, which includes the crypto.getRandomValues() method in UUID.

The work around is to remove the React.useId() and use our own generateUniqueId
Tested local build of Seldon on the latest version of phillips-public

**Change List (describe the changes made to the files)**

- Additions, Changes, and Removals. (You can use [GitHub Copilot PR Summary](https://docs.github.com/en/enterprise-cloud@latest/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot) to populate this section)

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-6222]: https://phillipsauctions.atlassian.net/browse/L3-6222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ