### PR TITLE
fix(Grid): L3-6072  Revert Add support for xl breakpoints and colStart props (#564)"

### DIFF
--- a/src/components/GridItem/GridItem.stories.tsx
+++ b/src/components/GridItem/GridItem.stories.tsx
@@ -2,7 +2,6 @@ import { Meta } from '@storybook/react';
 import GridItem, { type GridItemProps } from './GridItem';
 import Grid from '../Grid/Grid';
 import { GridItemAlign } from './types';
-import { useEffect, useState } from 'react';
 
 const meta = {
   title: 'Components/Layouts/GridItem',
@@ -10,83 +9,16 @@ const meta = {
 } satisfies Meta<typeof GridItem>;
 
 export default meta;
-
-const longParagraph = (
-  <p>
-    Harry Phillips founded the auction house in 1796 in Westminster, London. Phillips gained international recognition
-    by selling paintings from the estate of Queen Marie Antoinette and household items from Napoleon Bonaparte, and it
-    remains the only auction house to have ever held a sale inside Buckingham Palace. Harry Phillips was an innovator
-    who combined business acumen with showmanship, introducing elaborate evening receptions before auctions – a standard
-    practice in the auction business today.
-  </p>
-);
-
-const getBreakpoint = () => {
-  const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
-
-  useEffect(() => {
-    const handleResize = () => setViewportWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  if (viewportWidth <= 360) {
-    return 'xs';
-  }
-  if (viewportWidth <= 960) {
-    return 'sm';
-  }
-  if (viewportWidth <= 1400) {
-    return 'md';
-  }
-  if (viewportWidth <= 1800) {
-    return 'lg';
-  }
-  return 'xl';
-};
-
-const GridWrapper = ({ title = '', children }: { title?: string; children: React.ReactNode }) => (
-  <div style={{ marginTop: '2rem' }}>
-    {title ? <h2>{title}</h2> : null}
-    <div style={{ textAlign: 'center', padding: '0.5rem', fontWeight: 600 }}>Breakpoint: {getBreakpoint()}</div>
-    <Grid style={{ backgroundColor: '#4444AA', padding: '1rem' }}>{children}</Grid>
-  </div>
-);
-type GridChildProps = {
-  itemNum: number;
-  gridContent?: React.ReactNode;
-} & GridItemProps;
-
-const GridChild = ({ itemNum, gridContent, ...props }: GridChildProps) => (
-  <GridItem
-    key={itemNum}
-    style={{
-      backgroundColor: '#DDD',
-      padding: '1rem',
-      fontWeight: 500,
-      textAlign: 'center',
-    }}
-    {...props}
-  >
-    <div>{gridContent ?? `Item ${itemNum}`}</div>
-  </GridItem>
-);
 export const Playground = ({ children, ...props }: GridItemProps) => (
-  <GridWrapper>
-    {Array.from({ length: 12 }).map((_, i) => (
-      <GridItem key={i} {...props} style={{ backgroundColor: 'gray' }}>
-        <GridChild itemNum={i + 1} {...props} />
-      </GridItem>
-    ))}
-  </GridWrapper>
+  <Grid>
+    <GridItem {...props} style={{ backgroundColor: 'gray' }}>
+      {children}
+    </GridItem>
+  </Grid>
 );
 
 Playground.args = {
-  xs: 2,
-  sm: 1,
-  md: 2,
-  lg: 2,
-  align: GridItemAlign.left,
+  children: <div>Grid Item</div>,
 };
 
 Playground.argTypes = {
@@ -99,148 +31,41 @@ Playground.argTypes = {
 };
 
 export const CenteredGridItem = (props: GridItemProps) => (
-  <GridWrapper>
-    <GridChild itemNum={1} gridContent={longParagraph} {...props} />
-    <GridChild itemNum={2} gridContent={longParagraph} {...props} />
-  </GridWrapper>
+  <Grid>
+    <GridItem style={{ backgroundColor: 'gray' }} {...props} align={GridItemAlign.center}>
+      <p>
+        Harry Phillips founded the auction house in 1796 in Westminster, London. Phillips gained international
+        recognition by selling paintings from the estate of Queen Marie Antoinette and household items from Napoleon
+        Bonaparte, and it remains the only auction house to have ever held a sale inside Buckingham Palace. Harry
+        Phillips was an innovator who combined business acumen with showmanship, introducing elaborate evening
+        receptions before auctions – a standard practice in the auction business today.
+      </p>
+    </GridItem>
+    <GridItem style={{ backgroundColor: 'gray' }} {...props} align={GridItemAlign.center}>
+      <p>
+        Harry Phillips founded the auction house in 1796 in Westminster, London. Phillips gained international
+        recognition by selling paintings from the estate of Queen Marie Antoinette and household items from Napoleon
+        Bonaparte, and it remains the only auction house to have ever held a sale inside Buckingham Palace. Harry
+        Phillips was an innovator who combined business acumen with showmanship, introducing elaborate evening
+        receptions before auctions – a standard practice in the auction business today.
+      </p>
+    </GridItem>
+  </Grid>
 );
 
 CenteredGridItem.args = {
   sm: 2,
-  md: 3,
-  lg: 6,
-};
-
-CenteredGridItem.argTypes = {
-  align: {
-    options: GridItemAlign,
-    control: {
-      type: 'select',
-      options: [GridItemAlign.center],
-    },
-  },
+  md: 4,
+  lg: 8,
 };
 
 export const LeftAndRightGridItems = () => (
-  <GridWrapper>
-    <GridChild itemNum={1} sm={1} md={2} lg={4} align={GridItemAlign.left} />
-    <GridChild itemNum={2} sm={1} md={4} lg={6} align={GridItemAlign.right} />
-  </GridWrapper>
-);
-
-export const GridWithOffsetColumns = () => (
-  <>
-    <GridWrapper title="1 Child (Offset layout)">
-      <GridChild
-        xsColStart={2}
-        sm={1}
-        smColStart={2}
-        md={3}
-        mdColStart={4}
-        lg={6}
-        lgColStart={7}
-        xl={6}
-        xlColStart={7}
-        itemNum={1}
-        align={GridItemAlign.left}
-      />
-    </GridWrapper>
-    <GridWrapper title="2 Children (2 column layout)">
-      <GridChild
-        xs={1}
-        sm={1}
-        md={2}
-        mdColStart={1}
-        lg={4}
-        lgColStart={2}
-        xl={4}
-        xlColStart={2}
-        itemNum={1}
-        align={GridItemAlign.left}
-      />
-      <GridChild
-        xs={1}
-        sm={1}
-        md={2}
-        mdColStart={5}
-        lg={4}
-        lgColStart={8}
-        xl={4}
-        xlColStart={8}
-        itemNum={2}
-        align={GridItemAlign.right}
-      />
-    </GridWrapper>
-    <GridWrapper title="6 Children (Funky layout)">
-      <GridChild
-        xs={2}
-        sm={2}
-        md={1}
-        lg={1}
-        lgColStart={2}
-        xl={2}
-        xlColStart={11}
-        itemNum={1}
-        align={GridItemAlign.left}
-      />
-      <GridChild
-        xs={1}
-        sm={1}
-        smColStart={2}
-        md={4}
-        lg={1}
-        lgColStart={4}
-        xl={2}
-        xlColStart={9}
-        itemNum={2}
-        align={GridItemAlign.left}
-      />
-      <GridChild
-        xs={2}
-        sm={2}
-        md={1}
-        lg={1}
-        lgColStart={6}
-        xl={2}
-        xlColStart={7}
-        itemNum={3}
-        align={GridItemAlign.left}
-      />
-      <GridChild
-        xs={1}
-        sm={1}
-        smColStart={2}
-        md={1}
-        lg={1}
-        lgColStart={7}
-        xl={2}
-        xlColStart={5}
-        itemNum={4}
-        align={GridItemAlign.left}
-      />
-      <GridChild
-        xs={2}
-        sm={2}
-        md={4}
-        lg={1}
-        lgColStart={9}
-        xl={2}
-        xlColStart={3}
-        itemNum={5}
-        align={GridItemAlign.left}
-      />
-      <GridChild
-        xs={1}
-        sm={1}
-        smColStart={2}
-        md={1}
-        lg={1}
-        lgColStart={11}
-        xl={2}
-        xlColStart={1}
-        itemNum={6}
-        align={GridItemAlign.left}
-      />
-    </GridWrapper>
-  </>
+  <Grid>
+    <GridItem style={{ backgroundColor: 'gray' }} xs={1} sm={1} md={2} lg={4} align={GridItemAlign.left}>
+      <p>Left align</p>
+    </GridItem>
+    <GridItem style={{ backgroundColor: 'gray' }} xs={1} sm={1} md={4} lg={6} align={GridItemAlign.right}>
+      <p>Right align</p>
+    </GridItem>
+  </Grid>
 );

--- a/src/components/GridItem/GridItem.tsx
+++ b/src/components/GridItem/GridItem.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { BreakpointTokens, getCommonProps } from '../../utils';
+import { getCommonProps } from '../../utils';
 import classnames from 'classnames';
 import { determineColumnSpanClassName, validateColumnSpans } from './gridItemUtils';
 import { GridItemAlign } from './types';
@@ -10,45 +10,12 @@ export interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   align?: GridItemAlign;
   /**
-   * Determines how many columns this GridItem spans at the xs breakpoint, defaults to the maximum of 2 columns.  If there are less than 2 columns in the Grid at the xs breakpoint it will be centered.
+   * column spans at different breakpoints, defaults to all columns.  If less than the total number of columns at the breakpoint it will be centered.
    */
   xs?: number;
-  /**
-   * Determines how many columns this GridItem spans at the sm breakpoint, defaults to the maximum of 2 columns.  If there are less than 2 columns in the Grid at the sm breakpoint it will be centered.
-   */
   sm?: number;
-  /**
-   * Determines how many columns this GridItem spans at the md breakpoint, defaults to the maximum of 6 columns.  If there are less than 6 columns in the Grid at the md breakpoint they will be centered.
-   */
   md?: number;
-  /**
-   * Determines how many columns this GridItem spans at the lg breakpoint, defaults to the maximum of 12 columns.  If there are less than 2 columns in the Grid at the lg breakpoint they will be centered.
-   */
   lg?: number;
-  /**
-   * Determines how many columns this GridItem spans at the xl breakpoint, defaults to the maximum of 12 columns.  If there are less than 2 columns in the Grid at the xl breakpoint they will be centered.
-   */
-  xl?: number;
-  /**
-   * The starting column for this GridItem at the xs breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the xs breakpoint.
-   */
-  xsColStart?: number;
-  /**
-   * The starting column for this GridItem at the sm breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the sm breakpoint.
-   */
-  smColStart?: number;
-  /**
-   * The starting column for this GridItem at the md breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the md breakpoint.
-   */
-  mdColStart?: number;
-  /**
-   * The starting column for this GridItem at the lg breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the lg breakpoint.
-   */
-  lgColStart?: number;
-  /**
-   * The starting column for this GridItem at the xl breakpoint. If omitted, the GridItem will be placed in the next available column. Setting this value will override the alignment setting at the xl breakpoint.
-   */
-  xlColStart?: number;
   /**
    * Optional element to render as the top-level component e.g. 'div', 'span', CustomComponent, etc.  Defaults to 'div'.
    */
@@ -70,12 +37,6 @@ const GridItem = ({
   sm = 2,
   md = 6,
   lg = 12,
-  xl = 12,
-  xsColStart,
-  smColStart,
-  mdColStart,
-  lgColStart,
-  xlColStart,
   align = GridItemAlign.center,
   element: Element = 'div',
   className,
@@ -83,23 +44,16 @@ const GridItem = ({
 }: GridItemProps) => {
   const { className: baseClassName, ...commonProps } = getCommonProps(props, 'GridItem');
 
-  const columnSpansPerBreakpoint = useMemo(() => ({ xs, sm, md, lg, xl }) as const, [xs, sm, md, lg, xl]);
-  const columnStartsPerBreakpoint = useMemo(
-    () => ({ xs: xsColStart, sm: smColStart, md: mdColStart, lg: lgColStart, xl: xlColStart }),
-    [xsColStart, smColStart, mdColStart, lgColStart, xlColStart],
-  );
-
+  const columnSpansPerBreakpoint = useMemo(() => ({ xs, sm, md, lg }) as const, [xs, sm, md, lg]);
   const gridItemClasses = useMemo(() => {
     return [
       baseClassName, // figure out the class names for each breakpoint
-      Object.entries(columnSpansPerBreakpoint).map(([key, columnSpan]) => {
-        const columnStart = columnStartsPerBreakpoint[key as BreakpointTokens];
-
-        return determineColumnSpanClassName(key as BreakpointTokens, columnSpan, columnStart, align);
-      }),
+      Object.entries(columnSpansPerBreakpoint).map(([key, value]) =>
+        determineColumnSpanClassName(key as GridItemAlign, value, align),
+      ),
       className,
     ];
-  }, [baseClassName, columnSpansPerBreakpoint, className, columnStartsPerBreakpoint, align]);
+  }, [align, columnSpansPerBreakpoint, baseClassName, className]);
 
   if (!validateColumnSpans(Object.values(columnSpansPerBreakpoint))) {
     return null;

--- a/src/components/GridItem/_gridItem.scss
+++ b/src/components/GridItem/_gridItem.scss
@@ -2,7 +2,7 @@
 @use '#scss/allPartials' as *;
 
 @mixin gridItemColumnSpan($span: 1, $total-cols: 12) {
-  grid-column: auto / span $span;
+  grid-column: span $span;
 
   &-align-right {
     grid-column-end: $total-cols + 1;
@@ -24,22 +24,10 @@
     }
   }
 
-  @for $i from 1 through 6 {
-    &--start-xs-#{$i} {
-      grid-column-start: #{$i};
-    }
-  }
-
   @include media($size-sm) {
     @for $i from 1 through 2 {
       &--span-sm-#{$i} {
         @include gridItemColumnSpan($i, 2);
-      }
-    }
-
-    @for $i from 1 through 6 {
-      &--start-sm-#{$i} {
-        grid-column-start: #{$i};
       }
     }
   }
@@ -50,38 +38,12 @@
         @include gridItemColumnSpan($i, 6);
       }
     }
-
-    @for $i from 1 through 6 {
-      &--start-md-#{$i} {
-        grid-column-start: #{$i};
-      }
-    }
   }
 
   @include media($size-lg) {
     @for $i from 1 through 12 {
       &--span-lg-#{$i} {
         @include gridItemColumnSpan($i, 12);
-      }
-    }
-
-    @for $i from 1 through 12 {
-      &--start-lg-#{$i} {
-        grid-column-start: #{$i};
-      }
-    }
-  }
-
-  @include media($size-xl) {
-    @for $i from 1 through 12 {
-      &--span-xl-#{$i} {
-        @include gridItemColumnSpan($i, 12);
-      }
-    }
-
-    @for $i from 1 through 12 {
-      &--start-xl-#{$i} {
-        grid-column-start: #{$i};
       }
     }
   }

--- a/src/components/GridItem/gridItemUtils.ts
+++ b/src/components/GridItem/gridItemUtils.ts
@@ -1,19 +1,13 @@
-import { BreakpointTokens, px } from '../../utils';
+import { px } from '../../utils';
 import { GridItemProps } from './GridItem';
 import { GridItemAlign } from './types';
 
 export const determineColumnSpanClassName = (
-  breakpoint: BreakpointTokens,
+  breakpoint: GridItemAlign,
   columnSpan: number,
-  columnStart?: number,
   align: GridItemProps['align'] = GridItemAlign.center,
 ): string => {
-  const colSpanClass = `${px}-grid-item--span-${breakpoint}-${columnSpan}`;
-  // If columnStart is set, default align (left) is always used
-  const colAlignClass = `${px}-grid-item--span-${breakpoint}-${columnSpan}-align-${columnStart ? GridItemAlign.left : align}`;
-  const colStartClass = columnStart ? `${px}-grid-item--start-${breakpoint}-${columnStart}` : '';
-
-  return `${colSpanClass} ${colAlignClass} ${colStartClass}`.replace(/\s+/g, ' ').trim();
+  return `${px}-grid-item--span-${breakpoint}-${columnSpan} ${px}-grid-item--span-${breakpoint}-${columnSpan}-align-${align}`;
 };
 
 export const validateColumnSpans = (columnSpans: number[]) => {

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -34,14 +34,6 @@ export enum SpacingTokens {
   xxl = 'xxl',
 }
 
-export enum BreakpointTokens {
-  xs = 'xs',
-  sm = 'sm',
-  md = 'md',
-  lg = 'lg',
-  xl = 'xl',
-}
-
 /* eslint-disable @typescript-eslint/no-empty-function */
 export const noOp = () => {};
 


### PR DESCRIPTION

This reverts commit a447d79f47303770ca21ffc10a56fca88a946e8a.

**Summary**

This broke our grids in Remix because they assume that cols will be laid out to fill the available grid columns without specify a grid colum start property.

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- Check the Grid Item stories

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
