### PR TITLE
fix(Icons): L3-6336 fix fallback value for Icon color

### DIFF
--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -1,7 +1,7 @@
 import Icon from './Icon';
 import { render } from '@testing-library/react';
 
-const vars = vi.hoisted(() => '$pure-black: COLOR_DEFAULT;\n$test-color: COLOR_RED;\n');
+const vars = vi.hoisted(() => '$pure-black: #000000;\n$test-color: #FF0000;\n');
 vi.mock('#scss/_vars.scss?raw', () => ({ default: vars }));
 
 describe('Icon', () => {
@@ -25,13 +25,13 @@ describe('Icon', () => {
   it('should apply correct color style based on prop', () => {
     const { getByTestId } = render(<Icon icon="AccountCircle" height={32} width={32} color="$test-color" />);
     const icon = getByTestId('icon-account-circle');
-    expect(icon).toHaveAttribute('fill', 'COLOR_RED');
+    expect(icon).toHaveAttribute('fill', '#FF0000');
   });
 
   it('should apply default color if color prop is not found in vars', () => {
     const { getByTestId } = render(<Icon icon="AccountCircle" height={32} width={32} color="$fake-color" />);
     const icon = getByTestId('icon-account-circle');
-    expect(icon).toHaveAttribute('fill', '$pure-black');
+    expect(icon).toHaveAttribute('fill', '#000000');
   });
 
   it('should return null if icon does not exist', () => {

--- a/src/utils/scssUtils.test.ts
+++ b/src/utils/scssUtils.test.ts
@@ -13,12 +13,20 @@ describe('scssUtils', () => {
       expect(result).toBe('#000000');
     });
 
-    it('should return the default value if the scss variable does not exist', () => {
+    it('should return the color of the default value if the scss variable does not exist', () => {
       const scssVar = '$non-existent-var';
       const defaultValue = '$error-red';
 
       const result = getScssVar(scssVar, defaultValue);
-      expect(result).toBe('$error-red');
+      expect(result).toBe('#FF0000');
+    });
+
+    it('should return the default value if the scss variable does not exist AND the color of the default value is not found', () => {
+      const scssVar = '$non-existent-var';
+      const defaultValue = '$non-existent-default';
+
+      const result = getScssVar(scssVar, defaultValue);
+      expect(result).toBe('$non-existent-default');
     });
   });
 

--- a/src/utils/scssUtils.ts
+++ b/src/utils/scssUtils.ts
@@ -1,19 +1,25 @@
 import vars from '#scss/_vars.scss?raw';
 
-// This function parses the _vars.scss file into individual lines and returns the value of the variable passed in
-// If the variable is not found, it returns the default value passed in
-export const getScssVar = (scssVar: string, defaultValue: string): string => {
+export const getScssVarsMap = () => {
   const parsedVars = vars.split('\n').map((_var) => {
     const [name, value] = _var.split(': ');
     return { name, value: value?.replace(';', '') };
   });
-  const colorIndex = parsedVars.findIndex(({ name }) => name === scssVar);
+  const scssVarsMap: Record<string, string> = {};
 
-  if (scssVar && colorIndex > -1) {
-    return parsedVars[colorIndex].value;
-  }
+  parsedVars.forEach(({ name, value }) => {
+    if (name && value) {
+      scssVarsMap[name] = value;
+    }
+  });
+  return scssVarsMap;
+};
 
-  return defaultValue;
+// This function parses the _vars.scss file into individual lines and returns the value of the variable passed in
+// If the variable is not found, it returns the default value passed in
+export const getScssVar = (scssVar: string, defaultValue: string): string => {
+  const varsMap = getScssVarsMap();
+  return varsMap[scssVar] || varsMap[defaultValue] || defaultValue;
 };
 
 // Finds all color variables set in _vars.scss and returns the name of each

--- a/src/utils/scssUtils.ts
+++ b/src/utils/scssUtils.ts
@@ -19,7 +19,7 @@ export const getScssVarsMap = () => {
 // If the variable is not found, it returns the default value passed in
 export const getScssVar = (scssVar: string, defaultValue: string): string => {
   const varsMap = getScssVarsMap();
-  return varsMap[scssVar] || varsMap[defaultValue] || defaultValue;
+  return varsMap[scssVar] ?? varsMap[defaultValue] ?? defaultValue;
 };
 
 // Finds all color variables set in _vars.scss and returns the name of each


### PR DESCRIPTION
**Jira ticket**

[L3-6336](https://phillipsauctions.atlassian.net/browse/L3-6336)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/ecab2f36-0233-480f-b3bd-32014da2fb01) | ![image](https://github.com/user-attachments/assets/3fb31b22-23b7-4205-aa15-396481482b5e) |

**Figma link**

[Figma Link](https://www.figma.com/file/FIGMA-LINK)

**Summary**

Fixes an issue that was caused by the fact that the function responsible for setting the default color wasn't working properly. Now all `Icons` will have a default color of `$pure-black` aka (#000000) unless otherwise specified.

**Change List (describe the changes made to the files)**

This pull request includes changes to improve the handling of SCSS variables in the `Icon` component and its associated tests. The most important changes involve updating the color values to use hex codes instead of SCSS variable names and refactoring the utility function for retrieving SCSS variables.

### Updates to color handling:

* [`src/components/Icon/Icon.test.tsx`](diffhunk://#diff-417656a63db170a14e50704cf3e576d0bbf921441661c99d965eecd3cc2b973aL4-R4): Updated the color values in the tests to use hex codes (`#000000` and `#FF0000`) instead of SCSS variable names (`$pure-black` and `$test-color`). This change ensures that the tests check for the actual color values rather than the variable names. [[1]](diffhunk://#diff-417656a63db170a14e50704cf3e576d0bbf921441661c99d965eecd3cc2b973aL4-R4) [[2]](diffhunk://#diff-417656a63db170a14e50704cf3e576d0bbf921441661c99d965eecd3cc2b973aL28-R34)

### Refactoring SCSS utility functions:

* [`src/utils/scssUtils.ts`](diffhunk://#diff-5e62e3c736aee0039f5f756b51b4611e7ab9fc3004b5b984e433df188f366a18L3-R22): Refactored the `getScssVar` function to use a new helper function `getScssVarsMap`, which parses the SCSS variables into a map for easier lookup. This change improves the efficiency and readability of the code.
* [`src/utils/scssUtils.test.ts`](diffhunk://#diff-3cb6b53e2901364c67f3cd2d53c55eef0079cd6565cf4f000adbd6837c4324eaL16-R29): Added new test cases to cover scenarios where the SCSS variable or the default value does not exist. This ensures that the utility function behaves correctly in all edge cases.

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-3417]: https://phillipsauctions.atlassian.net/browse/L3-3417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[L3-6336]: https://phillipsauctions.atlassian.net/browse/L3-6336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ