### PR TITLE
fix(lotobjecttile): L3-6251 incorrect HTML nesting causing HTML validation errors and hydration errors

### DIFF
--- a/src/patterns/ObjectTile/ObjectTile.tsx
+++ b/src/patterns/ObjectTile/ObjectTile.tsx
@@ -140,12 +140,12 @@ const ObjectTile = memo(
             fetchPriority={imageFetchPriority}
           />
           {!withdrawnText ? (
-            <Text className={`${baseClassName}__badge`} variant={TextVariants.badge}>
+            <Text element="span" className={`${baseClassName}__badge`} variant={TextVariants.badge}>
               {badgeText}
             </Text>
           ) : null}
           <div className={`${baseClassName}__lot-number-like`}>
-            <Text className={`${baseClassName}__lot-number`} variant={TextVariants.heading4} element="p">
+            <Text element="span" className={`${baseClassName}__lot-number`} variant={TextVariants.heading4}>
               {lotNumber}
             </Text>
             {BadgeElement && (
@@ -156,14 +156,14 @@ const ObjectTile = memo(
             {FavoriteElement && <FavoriteElement />}
           </div>
           {withdrawnText ? (
-            <Text className={`${baseClassName}__withdrawn`} variant={TextVariants.heading4}>
+            <Text element="span" className={`${baseClassName}__withdrawn`} variant={TextVariants.heading4}>
               {withdrawnText}
             </Text> // TODO: Design calls for heading 4 but the values they have map to our current heading 5. This should be updated when we update those tokens.
           ) : (
             <>
               <div className={`${baseClassName}__meta`}>
                 {makerText ? (
-                  <Text className={`${baseClassName}__maker`} variant={TextVariants.heading4}>
+                  <Text element="span" className={`${baseClassName}__maker`} variant={TextVariants.heading4}>
                     {makerText}
                   </Text>
                 ) : null}
@@ -180,7 +180,7 @@ const ObjectTile = memo(
                   <Text
                     className={`${baseClassName}__reference-number ${baseClassName}__token-fix`}
                     variant={TextVariants.heading4}
-                    element="p"
+                    element="span"
                   >
                     {referenceNumber}
                   </Text>
@@ -189,7 +189,7 @@ const ObjectTile = memo(
                   <Text
                     className={`${baseClassName}__model ${baseClassName}__token-fix`}
                     variant={TextVariants.heading4}
-                    element="p"
+                    element="span"
                   >
                     {modelText}
                   </Text>

--- a/src/patterns/ObjectTile/_objectTile.scss
+++ b/src/patterns/ObjectTile/_objectTile.scss
@@ -13,6 +13,7 @@
 
   &__badge {
     color: $widget-red;
+    display: block; // Ensures the badge can be sized correctly
   }
 
   &__badge:empty {
@@ -47,7 +48,7 @@
     }
 
     .#{$px}-object-tile__lot-badge {
-      display: inline-block;
+      display: block;
       padding-left: $spacing-xsm;
       position: relative;
 
@@ -63,7 +64,7 @@
   }
 
   & .#{$px}-object-tile__lot-number {
-    display: inline-block;
+    display: block;
     margin-bottom: 0;
     padding-top: 2px;
   }
@@ -71,6 +72,7 @@
   & .#{$px}-object-tile__maker,
   & .#{$px}-object-tile__model,
   & .#{$px}-object-tile__reference-number {
+    display: block;
     margin-bottom: 0;
   }
 
@@ -80,6 +82,7 @@
   }
 
   &__meta {
+    display: block;
     margin-bottom: $spacing-sm;
   }
 


### PR DESCRIPTION
**Jira ticket**

[L3-6251](https://phillipsauctions.atlassian.net/browse/L3-6251)


**Summary**

We've been seeing hydration errors for a long time intermittently in Remix.  These seem to be [caused](https://nextjs.org/docs/messages/react-hydration-error#common-causes) by HTML that does not match the HTML specification being rendered server side.  Specifically trying to nest a `<div` in a `<p` element.  

**Change List (describe the changes made to the files)**

This pull request includes changes to the `ObjectTile` component in both `ObjectTile.tsx` and `_objectTile.scss` files. The primary goal of these changes is to update the `Text` component elements from `p` to `span` and ensure proper display styling for various elements.

### Changes to `ObjectTile.tsx`:

* Updated the `Text` component elements from `p` to `span` for badges, lot numbers, withdrawn text, maker text, reference numbers, and model text to improve semantic HTML. [[1]](diffhunk://#diff-8ed75c9c4bf0426a7e652657576880a82efc966be04761f900f967a445a6ee5bL143-R148) [[2]](diffhunk://#diff-8ed75c9c4bf0426a7e652657576880a82efc966be04761f900f967a445a6ee5bL159-R166) [[3]](diffhunk://#diff-8ed75c9c4bf0426a7e652657576880a82efc966be04761f900f967a445a6ee5bL183-R183) [[4]](diffhunk://#diff-8ed75c9c4bf0426a7e652657576880a82efc966be04761f900f967a445a6ee5bL192-R192)

### Changes to `_objectTile.scss`:

* Added `display: block` to various elements to ensure correct sizing and layout, including badges, lot numbers, maker text, model text, reference numbers, and meta information. [[1]](diffhunk://#diff-ec8030c569734129d8b39db46426ee5b43fc60c7a48152c4ea3605bba1a9840dR16) [[2]](diffhunk://#diff-ec8030c569734129d8b39db46426ee5b43fc60c7a48152c4ea3605bba1a9840dL50-R51) [[3]](diffhunk://#diff-ec8030c569734129d8b39db46426ee5b43fc60c7a48152c4ea3605bba1a9840dL66-R75) [[4]](diffhunk://#diff-ec8030c569734129d8b39db46426ee5b43fc60c7a48152c4ea3605bba1a9840dR85)

**Acceptance Test (how to verify the PR)**
- Do a production build of Remix point `.env` to stage and start the prod server
- Login to your localhost Remix server
- Load this URL in a browser, and force refresh it
- http://localhost:3000/auction/NY080425/browse
If you try and favorite a lot, the drawer will be broken
You will also see a hydration error in the console
```
hook.js:608 Error: Minified React error #418; visit https://reactjs.org/docs/error-decoder.html?invariant=418 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at lu (react-dom.production.min.js:131:278)
    at dg (react-dom.production.min.js:292:379)
    at Ag (react-dom.production.min.js:279:389)
    at p4 (react-dom.production.min.js:279:362)
    at ag (react-dom.production.min.js:267:300)
    at S (scheduler.production.min.js:13:203)
    at MessagePort.M (scheduler.production.min.js:14:128)
```

- Build seldon
- Go to Remix project, replace the `/dist` directory from the built seldon over the `node_modules/@phillips/seldon/dist directory
- Rerun the same test the hydration error should go away
- If you try and favorite a lot the drawer should look correct.


**Regression Test**

- Look at all the lot tiles for different auctions in the browse tab and make sure the styles look correct.

**Evidence of testing**
![image](https://github.com/user-attachments/assets/6fbec84f-1289-4f73-a2f6-9431c519779d)


<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-6251]: https://phillipsauctions.atlassian.net/browse/L3-6251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ