### PR TITLE
fix(prefetching): L3-6129 remove module <link>

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -55,8 +55,6 @@ describe('Button', () => {
     await waitFor(() => {
       expect(screen.getByTestId('prefetch-link')).toHaveAttribute('rel', 'prefetch');
       expect(screen.getByTestId('prefetch-link')).toHaveAttribute('href', 'https://example.com');
-      expect(screen.getByTestId('modulepreload-link')).toHaveAttribute('rel', 'modulepreload');
-      expect(screen.getByTestId('modulepreload-link')).toHaveAttribute('href', 'https://example.com');
     });
   });
 
@@ -72,7 +70,6 @@ describe('Button', () => {
     });
     await waitFor(() => {
       expect(screen.queryByTestId('prefetch-link')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('modulepreload-link')).not.toBeInTheDocument();
     });
   });
 
@@ -85,14 +82,12 @@ describe('Button', () => {
     const anchorElement = screen.getByText('Link');
     await waitFor(() => {
       expect(screen.queryByTestId('prefetch-link')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('modulepreload-link')).not.toBeInTheDocument();
     });
     act(() => {
       anchorElement.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     });
     await waitFor(() => {
       expect(screen.getByTestId('prefetch-link')).toBeInTheDocument();
-      expect(screen.getByTestId('modulepreload-link')).toBeInTheDocument();
     });
   });
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -81,7 +81,6 @@ const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
       const PreloadLinks = () => (
         <>
           <link data-testid="prefetch-link" rel="prefetch" href={href} />
-          <link data-testid="modulepreload-link" rel="modulepreload" href={href} />
         </>
       );
       return (


### PR DESCRIPTION
**Jira ticket**

[L3-6129](https://phillipsauctions.atlassian.net/browse/L3-6129)

**Summary**

The `modulepreload-link` doesn't actually live at `href`, it lives at some remix specific location `href/asset2343something.js`, which doesn't make sense to calculate in seldon

perhaps there is a more sophisticated change we could make where we pass in the remic `Link` component from the consumer, but for now we should just remove the `<link>` tag which is throwing the error

**Change List (describe the changes made to the files)**

- Remove the `modulepreload-link` tag from the button

**Acceptance Test (how to verify the PR)**

- No more console log errors when using the lot navigator in remix

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-6129]: https://phillipsauctions.atlassian.net/browse/L3-6129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ