### PR TITLE
feat(countdown): L3-6379 allow custom currentDate prop

### DIFF
--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -43,6 +43,7 @@ export interface CountdownProps extends ComponentProps<'div'> {
    * Variant of the countdown
    */
   variant?: CountdownVariants;
+  currentDateTime?: Date;
 }
 /**
  * ## Overview
@@ -64,12 +65,13 @@ const Countdown = forwardRef<HTMLDivElement, CountdownProps>(
       locale = 'en',
       showBottomBorder = true,
       variant = CountdownVariants.default,
+      currentDateTime: currentDateTimeProp = new Date(),
       ...props
     },
     ref,
   ) => {
     const { className: baseClassName, ...commonProps } = getCommonProps(props, 'Countdown');
-    const [currentDateTime, setCurrentDateTime] = useState(new Date());
+    const [currentDateTime, setCurrentDateTime] = useState(currentDateTimeProp);
 
     const dateFnsLocale = locale === SupportedLanguages.zh ? zhCN : enUS;
 
@@ -89,22 +91,24 @@ const Countdown = forwardRef<HTMLDivElement, CountdownProps>(
 
     useEffect(() => {
       const timer = setInterval(() => {
-        setCurrentDateTime(new Date());
+        setCurrentDateTime((currentTime) => {
+          return new Date(currentTime.getTime() + 1000);
+        });
       }, 1000);
 
       return () => clearInterval(timer);
-    }, [endDateTime]);
+    }, [endDateTime, currentDateTimeProp]);
 
     const showTimer = useMemo(() => {
-      return new Date(endDateTime).getTime() > new Date().getTime();
-    }, [endDateTime]);
+      return new Date(endDateTime).getTime() > currentDateTimeProp.getTime();
+    }, [endDateTime, currentDateTimeProp]);
 
     const isClosingTag = differenceInMilliseconds(endDateTime, currentDateTime) <= 3 * 60 * 1000;
 
     return showTimer ? (
       <div
         {...commonProps}
-        className={classnames(baseClassName, className, {
+        className={classnames('some-stupid-classname', baseClassName, className, {
           [`${baseClassName}--compact`]: variant === CountdownVariants.compact,
           [`${baseClassName}--show-bottom-border`]: showBottomBorder,
           [`${baseClassName}--closing-lot`]: isClosingTag,

--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -100,6 +100,7 @@ const Countdown = forwardRef<HTMLDivElement, CountdownProps>(
     }, [endDateTime, currentDateTimeProp]);
 
     const showTimer = useMemo(() => {
+      // we use the prop instead of the state variable to avoid hiding the timer when it hits 0
       return new Date(endDateTime).getTime() > currentDateTimeProp.getTime();
     }, [endDateTime, currentDateTimeProp]);
 
@@ -108,7 +109,7 @@ const Countdown = forwardRef<HTMLDivElement, CountdownProps>(
     return showTimer ? (
       <div
         {...commonProps}
-        className={classnames('some-stupid-classname', baseClassName, className, {
+        className={classnames(baseClassName, className, {
           [`${baseClassName}--compact`]: variant === CountdownVariants.compact,
           [`${baseClassName}--show-bottom-border`]: showBottomBorder,
           [`${baseClassName}--closing-lot`]: isClosingTag,

--- a/src/patterns/BidSnapshot/BidSnapshot.tsx
+++ b/src/patterns/BidSnapshot/BidSnapshot.tsx
@@ -80,6 +80,10 @@ export interface BidSnapshotProps extends ComponentProps<'div'> {
    * Won for label text, a string for label of won for detail
    */
   wonForText?: string;
+  /**
+   * Current date time
+   */
+  currentDateTime?: Date;
 }
 
 const bidsTranslation = (numberOfBids: number) => (numberOfBids === 1 ? `${numberOfBids} bid` : `${numberOfBids} bids`);
@@ -114,6 +118,7 @@ const BidSnapshot = forwardRef<HTMLDivElement, BidSnapshotProps>(
       soldPrice,
       soldForText = 'Sold for',
       wonForText = 'Won for',
+      currentDateTime = new Date(),
       ...props
     },
     ref,
@@ -124,7 +129,7 @@ const BidSnapshot = forwardRef<HTMLDivElement, BidSnapshotProps>(
     const isReady = lotStatus === LotStatus.ready;
     const isLive = lotStatus === LotStatus.live;
     const isPast = lotStatus === LotStatus.past;
-    const now = new Date();
+    const now = currentDateTime;
     const hasCountdownTimer =
       isLive &&
       lotCloseDate &&


### PR DESCRIPTION
**Jira ticket**

[L3-6379](https://phillipsauctions.atlassian.net/browse/L3-6379)

**Summary**

Add a `currentDateTime` prop to the `Countdown` and `BidSnapshot` components to override `new Date()`, when we don't want to rely on the user's machine time

**Change List (describe the changes made to the files)**


This pull request introduces enhancements to the `Countdown` and `BidSnapshot` components by adding support for a `currentDateTime` prop, which improves testability and allows external control of the current time. The changes also include adjustments to internal logic to utilize this new prop.

### Changes to `Countdown` component:

* Added a new optional `currentDateTime` prop to the `CountdownProps` interface. (`[src/components/Countdown/Countdown.tsxR46](diffhunk://#diff-9e886c1eb76bd42362402a2c88d7e3ee8c39be450c5d465c96b8603abe3ded89R46)`)
* Updated the `Countdown` component to initialize the `currentDateTime` state with the provided prop or default to the current date. (`[src/components/Countdown/Countdown.tsxR68-R74](diffhunk://#diff-9e886c1eb76bd42362402a2c88d7e3ee8c39be450c5d465c96b8603abe3ded89R68-R74)`)
* Modified the `useEffect` timer logic to increment `currentDateTime` by one second instead of creating a new `Date` object, ensuring consistency with the provided prop. (`[src/components/Countdown/Countdown.tsxL92-R111](diffhunk://#diff-9e886c1eb76bd42362402a2c88d7e3ee8c39be450c5d465c96b8603abe3ded89L92-R111)`)
* Adjusted the `showTimer` calculation to compare `endDateTime` with `currentDateTimeProp` instead of the current system time. (`[src/components/Countdown/Countdown.tsxL92-R111](diffhunk://#diff-9e886c1eb76bd42362402a2c88d7e3ee8c39be450c5d465c96b8603abe3ded89L92-R111)`)

### Changes to `BidSnapshot` component:

* Introduced an optional `currentDateTime` prop to the `BidSnapshotProps` interface. (`[src/patterns/BidSnapshot/BidSnapshot.tsxR83-R86](diffhunk://#diff-023608454dd8a373f83e678913fe1db898600977d93505f7afa1ff759b3c3e59R83-R86)`)
* Replaced the `now` variable with the `currentDateTime` prop to determine the current time, aligning with the new prop-based approach. (`[src/patterns/BidSnapshot/BidSnapshot.tsxL127-R132](diffhunk://#diff-023608454dd8a373f83e678913fe1db898600977d93505f7afa1ff759b3c3e59L127-R132)`)

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-6379]: https://phillipsauctions.atlassian.net/browse/L3-6379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ