### PR TITLE
fix(countdown): L3-6379 pass currentDateTime props through countdown …

### DIFF
--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -43,6 +43,9 @@ export interface CountdownProps extends ComponentProps<'div'> {
    * Variant of the countdown
    */
   variant?: CountdownVariants;
+  /**
+   * The current date time (defaults to new Date())
+   */
   currentDateTime?: Date;
 }
 /**

--- a/src/components/Countdown/_countdown.scss
+++ b/src/components/Countdown/_countdown.scss
@@ -30,12 +30,12 @@
 
   &--compact {
     .#{$px}-countdown__countdown-container {
+      gap: $spacing-xsm;
+
       @include Montserrat;
       .#{$px}-duration {
         @include Montserrat;
       }
-
-      gap: $spacing-xsm;
     }
   }
 

--- a/src/patterns/BidSnapshot/BidSnapshot.tsx
+++ b/src/patterns/BidSnapshot/BidSnapshot.tsx
@@ -179,6 +179,7 @@ const BidSnapshot = forwardRef<HTMLDivElement, BidSnapshotProps>(
             locale={SupportedLanguages[lang]}
             formatDurationStr={formatDurationStr}
             showBottomBorder={false}
+            currentDateTime={now}
           />
         ) : null}
       </div>

--- a/src/patterns/SaleHeaderBanner/SaleHeaderBanner.tsx
+++ b/src/patterns/SaleHeaderBanner/SaleHeaderBanner.tsx
@@ -130,7 +130,7 @@ const SaleHeaderBanner = forwardRef<HTMLDivElement, SaleHeaderBannerProps>(
       label: countdownTimerLabel,
       formatDurationStr: countdownFormatDuration,
       currentDateTime,
-    };
+    } satisfies CountdownProps;
 
     return (
       <div {...commonProps} className={classnames(baseClassName, className)} {...props} ref={ref}>

--- a/src/patterns/SaleHeaderBanner/SaleHeaderBanner.tsx
+++ b/src/patterns/SaleHeaderBanner/SaleHeaderBanner.tsx
@@ -118,7 +118,7 @@ const SaleHeaderBanner = forwardRef<HTMLDivElement, SaleHeaderBannerProps>(
       footerElement,
       headerLabel,
       showTimer,
-      currentDateTime = new Date(),
+      currentDateTime,
       ...props
     },
     ref,

--- a/src/patterns/SaleHeaderBanner/SaleHeaderBanner.tsx
+++ b/src/patterns/SaleHeaderBanner/SaleHeaderBanner.tsx
@@ -82,6 +82,10 @@ export interface SaleHeaderBannerProps extends ComponentProps<'div'> {
    * What action does the CTA take?
    */
   onClick?: () => void;
+  /**
+   * Current date time (defaults to new Date())
+   */
+  currentDateTime?: Date;
 }
 /**
  * ## Overview
@@ -114,6 +118,7 @@ const SaleHeaderBanner = forwardRef<HTMLDivElement, SaleHeaderBannerProps>(
       footerElement,
       headerLabel,
       showTimer,
+      currentDateTime = new Date(),
       ...props
     },
     ref,
@@ -124,6 +129,7 @@ const SaleHeaderBanner = forwardRef<HTMLDivElement, SaleHeaderBannerProps>(
       endDateTime: auctionEndTime as Date,
       label: countdownTimerLabel,
       formatDurationStr: countdownFormatDuration,
+      currentDateTime,
     };
 
     return (


### PR DESCRIPTION
…consumers

**Jira ticket**

[L3-6379](https://phillipsauctions.atlassian.net/browse/L3-6379)

**Summary**

Forgot to pass some `currentDateTime` props in https://github.com/PhillipsAuctionHouse/seldon/pulls?q=is:pr+is:closed

**Change List (describe the changes made to the files)**

- Pass `currentDateTime` props through the `SaleHeaderBanner` and `BidSnapshot` components

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-6379]: https://phillipsauctions.atlassian.net/browse/L3-6379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ