### PR TITLE
feat(ContentPeek): L3-6647 default ContentPeek to show 100% while loa…

### DIFF
--- a/src/components/ContentPeek/_contentPeek.scss
+++ b/src/components/ContentPeek/_contentPeek.scss
@@ -10,7 +10,7 @@
     overflow: hidden;
 
     &[data-state='closed'] {
-      max-height: var(--content-peek-max-height);
+      max-height: var(--content-peek-max-height, 100%);
     }
   }
 

--- a/src/components/ContentPeek/_contentPeek.scss
+++ b/src/components/ContentPeek/_contentPeek.scss
@@ -10,7 +10,7 @@
     overflow: hidden;
 
     &[data-state='closed'] {
-      max-height: var(--content-peek-max-height, 100%);
+      max-height: var(--content-peek-max-height, none);
     }
   }
 


### PR DESCRIPTION
…ding

**Jira ticket**

[L3-6647](https://phillipsauctions.atlassian.net/browse/L3-6647)

**Summary**

The PR adds a fallback value of `none` to the size of the content peek container. This causes the container to fully display until the client side rendering happens, at which point, the `--content-peek-max-height` var gets set and properly renders the ContentPeek. This should address the issue where sometimes the ContentPeek doesn't finish rendering and leaves the content cutoff. Now, if that happens, it should just leave the content fully visible instead of partially cut off. I don't really like the way everything sort of pops in and snaps after loading (see video), so maybe we can look at an improvement for this component in the future to more smoothly handle the load in, but this at least should fix that one issue for now

**Change List (describe the changes made to the files)**

This pull request includes a minor update to the `_contentPeek.scss` file. The change ensures a fallback value (`100%`) is provided for the `--content-peek-max-height` CSS variable when it is not defined. 

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**


https://github.com/user-attachments/assets/d4c044e5-4499-4324-a76b-9da8e5d5a1ed



<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-6647]: https://phillipsauctions.atlassian.net/browse/L3-6647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ