### PR TITLE
feat(favoritesCollectionTile): L3-7093 favorites collection tile fixes

### DIFF
--- a/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.stories.tsx
+++ b/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.stories.tsx
@@ -22,7 +22,7 @@ Playground.args = {
   id: 'favorites-collection-tile-1',
   count: 2,
   name: 'New List',
-  imageSrc: 'https://via.placeholder.com/400',
+  imageSrc: 'https://picsum.photos/160/90',
   variant: 'lists',
   onEdit: (): void => console.log('Edit list clicked'),
   onDelete: (): void => console.log('Delete list clicked'),
@@ -73,6 +73,7 @@ CreateList.args = {
   variant: 'create',
   element: 'a',
   linkClassName: linkClassName,
+  onClick: () => alert('Create new list clicked'),
 };
 
 export const EmptyList = (props: ComponentProps<typeof FavoritesCollectionTile>) => (

--- a/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.test.tsx
+++ b/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.test.tsx
@@ -143,10 +143,10 @@ describe('FavoritesCollectionTile', () => {
   it('renders a button for the create variant with correct aria-label and calls onClick', () => {
     const onClick = vi.fn();
     render(<FavoritesCollectionTile {...blankListProps} variant="create" onClick={onClick} />);
-    const button = screen.getByRole('button', { name: /Create List/i });
+    const button = screen.getByRole('button', { name: 'Create your first List.' });
     expect(button).toBeInTheDocument();
 
-    expect(button).toHaveAttribute('aria-label', 'Create List');
+    expect(button).toHaveAttribute('aria-label', 'Create your first List.');
     button.focus();
     button.click();
     expect(onClick).toHaveBeenCalled();
@@ -186,12 +186,11 @@ describe('FavoritesCollectionTile', () => {
     expect(onClick).toHaveBeenCalledTimes(2);
   });
   it('renders the correct aria-label for the create variant', () => {
-    render(<FavoritesCollectionTile {...blankListProps} variant="create" createAriaLabel="Create List" />);
-    const container = screen.getByTestId('create-list');
-    expect(container).toBeInTheDocument();
-    expect(container).toHaveAttribute('aria-label', 'Create List');
+    render(<FavoritesCollectionTile {...blankListProps} variant="create" createFirstListText="Create List" />);
+    const button = screen.getByTestId('create-list');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-label', 'Create List');
   });
-
   it('renders the correct aria-label for the favorites empty state', () => {
     render(
       <FavoritesCollectionTile

--- a/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.test.tsx
+++ b/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.test.tsx
@@ -143,10 +143,10 @@ describe('FavoritesCollectionTile', () => {
   it('renders a button for the create variant with correct aria-label and calls onClick', () => {
     const onClick = vi.fn();
     render(<FavoritesCollectionTile {...blankListProps} variant="create" onClick={onClick} />);
-    const button = screen.getByRole('button', { name: /lists/i });
+    const button = screen.getByRole('button', { name: /Create List/i });
     expect(button).toBeInTheDocument();
 
-    expect(button).toHaveAttribute('aria-label', 'Lists');
+    expect(button).toHaveAttribute('aria-label', 'Create List');
     button.focus();
     button.click();
     expect(onClick).toHaveBeenCalled();
@@ -176,7 +176,7 @@ describe('FavoritesCollectionTile', () => {
   it('calls onClick when pressing Enter or Space on the create variant', async () => {
     const onClick = vi.fn();
     render(<FavoritesCollectionTile {...blankListProps} variant="create" onClick={onClick} />);
-    const tile = screen.getByTestId('list');
+    const tile = screen.getByTestId('create-list');
     tile.focus();
 
     await userEvent.keyboard('{Enter}');
@@ -184,5 +184,38 @@ describe('FavoritesCollectionTile', () => {
 
     await userEvent.keyboard(' ');
     expect(onClick).toHaveBeenCalledTimes(2);
+  });
+  it('renders the correct aria-label for the create variant', () => {
+    render(<FavoritesCollectionTile {...blankListProps} variant="create" createAriaLabel="Create List" />);
+    const container = screen.getByTestId('create-list');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-label', 'Create List');
+  });
+
+  it('renders the correct aria-label for the favorites empty state', () => {
+    render(
+      <FavoritesCollectionTile
+        {...{ ...defaultProps, count: 0 }}
+        variant="favorites"
+        favoritesAriaLabel="Favorites Empty State"
+      />,
+    );
+    const container = screen.getByTestId('favorites');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-label', 'Favorites Empty State');
+  });
+
+  it('renders the correct aria-label for the lists empty state', () => {
+    render(<FavoritesCollectionTile {...emptyListProps} variant="lists" emptyListAriaLabel="Empty Lists State" />);
+    const container = screen.getByTestId('empty-list');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-label', 'Empty Lists State');
+  });
+
+  it('renders the correct aria-label for a list with data', () => {
+    render(<FavoritesCollectionTile {...defaultProps} variant="lists" listAriaLabel="List with Data" />);
+    const container = screen.getByTestId('list');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveAttribute('aria-label', 'List with Data');
   });
 });

--- a/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
+++ b/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
@@ -228,7 +228,7 @@ const FavoritesCollectionTile = memo(
                 <div className={`${baseClassName}__create-spacing`}></div>
                 <div
                   className={`${baseClassName}__media-container`}
-                  data-testid="list"
+                  data-testid="create-list"
                   aria-label={createAriaLabel}
                   role="button"
                   tabIndex={0}
@@ -287,7 +287,7 @@ const FavoritesCollectionTile = memo(
                 {isHasListAndCountEmpty && isListVariant && (
                   <div
                     className={`${baseClassName}__media-container`}
-                    data-testid="list"
+                    data-testid="empty-list"
                     aria-label={emptyListAriaLabel}
                   >
                     <div
@@ -314,7 +314,12 @@ const FavoritesCollectionTile = memo(
                 )}
 
                 {!isCountEmpty && hasListData && (
-                  <div className={`${baseClassName}__media-container`} ref={imageRef} aria-label={listAriaLabel}>
+                  <div
+                    className={`${baseClassName}__media-container`}
+                    ref={imageRef}
+                    aria-label={listAriaLabel}
+                    data-testid="list"
+                  >
                     <SeldonImage
                       alt={name}
                       aspectRatio="1/1"

--- a/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
+++ b/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
@@ -83,10 +83,6 @@ export interface FavoritesCollectionTileProps extends ComponentProps<'div'> {
   /**
    * ARIA label for the create variant container
    */
-  createAriaLabel?: string;
-  /**
-   * ARIA label for the favorites empty state
-   */
   favoritesAriaLabel?: string;
   /**
    * ARIA label for the lists empty state
@@ -130,7 +126,6 @@ const FavoritesCollectionTile = memo(
         linkClassName,
         iconSize = 22,
         menuAriaLabel = 'Manage List',
-        createAriaLabel = 'Create List',
         favoritesAriaLabel = 'Favorites',
         emptyListAriaLabel = 'Empty List',
         listAriaLabel = 'List',
@@ -188,6 +183,7 @@ const FavoritesCollectionTile = memo(
                             height={iconSize}
                             color="$dark-gray"
                             className={`${baseClassName}__icon-button`}
+                            aria-hidden="true"
                           />
                         </div>
                       </div>
@@ -224,42 +220,30 @@ const FavoritesCollectionTile = memo(
               </>
             </div>
             {isCreateVariant ? (
-              <>
-                <div className={`${baseClassName}__create-spacing`}></div>
-                <div
-                  className={`${baseClassName}__media-container`}
-                  data-testid="create-list"
-                  aria-label={createAriaLabel}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      props.onClick?.(e as unknown as React.MouseEvent<HTMLDivElement>);
-                    }
-                  }}
-                >
-                  <div
-                    className={classnames(`${baseClassName}__empty`, {
-                      [`${baseClassName}__empty--create-list`]: !hasListData,
-                    })}
-                  >
-                    <div className={`${baseClassName}__empty__content`}>
-                      <Icon
-                        icon="Add"
-                        width={iconSize}
-                        height={iconSize}
-                        color="$dark-gray"
-                        className={classnames(`${baseClassName}__icon`, {
-                          [`${baseClassName}__icon-circle`]: !hasListData,
-                        })}
-                        title="Create List"
-                      />
-                      <div className={`${baseClassName}__text`}>{createFirstListText}</div>
-                    </div>
-                  </div>
-                </div>
-              </>
+              <button
+                type="button"
+                className={`${baseClassName}__create-variant`}
+                data-testid="create-list"
+                aria-label={createFirstListText}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  props.onClick?.(e as unknown as React.MouseEvent<HTMLDivElement>);
+                }}
+              >
+                <span className={classnames(`${baseClassName}__empty`, `${baseClassName}__empty--create-list`)}>
+                  <span className={`${baseClassName}__empty__content`}>
+                    <Icon
+                      icon="Add"
+                      width={iconSize}
+                      height={iconSize}
+                      color="$dark-gray"
+                      className={classnames(`${baseClassName}__icon`, `${baseClassName}__icon-circle`)}
+                      aria-hidden="true"
+                    />
+                    <span className={`${baseClassName}__text`}>{createFirstListText}</span>
+                  </span>
+                </span>
+              </button>
             ) : (
               <Component href={href} className={classnames(`${baseClassName}__media-link`, linkClassName)} tabIndex={0}>
                 {isCountEmpty && variant === 'favorites' && (
@@ -276,7 +260,7 @@ const FavoritesCollectionTile = memo(
                           height={iconSize}
                           color="$dark-gray"
                           className={`${baseClassName}__icon`}
-                          title="Favorites"
+                          aria-hidden="true"
                         />
                         <div className={`${baseClassName}__text`}>{emptyFavoritesText}</div>
                       </div>
@@ -305,7 +289,7 @@ const FavoritesCollectionTile = memo(
                           className={classnames(`${baseClassName}__icon`, {
                             [`${baseClassName}__icon-circle`]: !hasListData,
                           })}
-                          title="Favorite"
+                          aria-hidden="true"
                         />
                         <div className={`${baseClassName}__text`}>{emptyListsText}</div>
                       </div>

--- a/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
+++ b/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
@@ -146,6 +146,8 @@ const FavoritesCollectionTile = memo(
                         data-testid="menu-trigger"
                         tabIndex={0}
                         role="button"
+                        aria-label="Manage List"
+                        aria-haspopup="menu"
                         onKeyDown={(event) => {
                           if (event.key === 'Enter') {
                             event.preventDefault();
@@ -161,6 +163,7 @@ const FavoritesCollectionTile = memo(
                             height={iconSize}
                             color="$dark-gray"
                             className={`${baseClassName}__icon-button`}
+                            title="Manage List"
                           />
                         </div>
                       </div>
@@ -196,68 +199,101 @@ const FavoritesCollectionTile = memo(
                 )}
               </>
             </div>
-            <Component href={href} className={classnames(`${baseClassName}__media-link`, linkClassName)} tabIndex={0}>
-              {isCountEmpty && variant === 'favorites' && (
-                <div className={`${baseClassName}__media-container`} data-testid="favorites" aria-label="Favorites">
-                  <div className={classnames(`${baseClassName}__empty`, `${baseClassName}__empty--bg`)}>
+            {isCreateVariant ? (
+              <>
+                <div className={`${baseClassName}__create-spacing`}></div>
+                <div
+                  className={`${baseClassName}__media-container`}
+                  data-testid="list"
+                  aria-label="Lists"
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      props.onClick?.(e as unknown as React.MouseEvent<HTMLDivElement>);
+                    }
+                  }}
+                >
+                  <div
+                    className={classnames(`${baseClassName}__empty`, {
+                      [`${baseClassName}__empty--create-list`]: !hasListData,
+                    })}
+                  >
                     <div className={`${baseClassName}__empty__content`}>
                       <Icon
-                        icon="Favorite"
+                        icon="Add"
                         width={iconSize}
                         height={iconSize}
                         color="$dark-gray"
-                        className={`${baseClassName}__icon`}
+                        className={classnames(`${baseClassName}__icon`, {
+                          [`${baseClassName}__icon-circle`]: !hasListData,
+                        })}
                       />
-                      <div className={`${baseClassName}__text`}>{emptyFavoritesText}</div>
+                      <div className={`${baseClassName}__text`}>{createFirstListText}</div>
                     </div>
                   </div>
                 </div>
-              )}
+              </>
+            ) : (
+              <Component href={href} className={classnames(`${baseClassName}__media-link`, linkClassName)} tabIndex={0}>
+                {isCountEmpty && variant === 'favorites' && (
+                  <div className={`${baseClassName}__media-container`} data-testid="favorites" aria-label="Favorites">
+                    <div className={classnames(`${baseClassName}__empty`, `${baseClassName}__empty--bg`)}>
+                      <div className={`${baseClassName}__empty__content`}>
+                        <Icon
+                          icon="Favorite"
+                          width={iconSize}
+                          height={iconSize}
+                          color="$dark-gray"
+                          className={`${baseClassName}__icon`}
+                        />
+                        <div className={`${baseClassName}__text`}>{emptyFavoritesText}</div>
+                      </div>
+                    </div>
+                  </div>
+                )}
 
-              {(isCountEmpty || !hasListData) && (isListVariant || isCreateVariant) && (
-                <>
-                  {isCreateVariant && <div className={`${baseClassName}__create-spacing`}></div>}
+                {isHasListAndCountEmpty && isListVariant && (
                   <div className={`${baseClassName}__media-container`} data-testid="list" aria-label="Lists">
                     <div
                       className={classnames(`${baseClassName}__empty`, {
-                        [`${baseClassName}__empty--create-list`]: !hasListData && (isListVariant || isCreateVariant),
-                        [`${baseClassName}__empty--bg`]: isCountEmpty && !isCreateVariant,
+                        [`${baseClassName}__empty--create-list`]: !hasListData,
+                        [`${baseClassName}__empty--bg`]: isCountEmpty,
                       })}
                     >
                       <div className={`${baseClassName}__empty__content`}>
                         <Icon
-                          icon={isHasListAndCountEmpty ? 'Favorite' : 'Add'}
+                          icon="Favorite"
                           width={iconSize}
                           height={iconSize}
                           color="$dark-gray"
                           className={classnames(`${baseClassName}__icon`, {
-                            [`${baseClassName}__icon-circle`]: !hasListData && (isListVariant || isCreateVariant),
+                            [`${baseClassName}__icon-circle`]: !hasListData,
                           })}
                         />
-                        <div className={`${baseClassName}__text`}>
-                          {isHasListAndCountEmpty ? emptyListsText : createFirstListText}
-                        </div>
+                        <div className={`${baseClassName}__text`}>{emptyListsText}</div>
                       </div>
                     </div>
                   </div>
-                </>
-              )}
+                )}
 
-              {!isCountEmpty && hasListData && (
-                <div className={`${baseClassName}__media-container`} ref={imageRef}>
-                  <SeldonImage
-                    alt={name}
-                    aspectRatio="1/1"
-                    className={`${baseClassName}__media`}
-                    objectFit="cover"
-                    src={imageSrc}
-                    style={{
-                      cursor: 'pointer',
-                    }}
-                  />
-                </div>
-              )}
-            </Component>
+                {!isCountEmpty && hasListData && (
+                  <div className={`${baseClassName}__media-container`} ref={imageRef}>
+                    <SeldonImage
+                      alt={name}
+                      aspectRatio="1/1"
+                      className={`${baseClassName}__media`}
+                      objectFit="contain"
+                      src={imageSrc}
+                      style={{
+                        cursor: 'pointer',
+                      }}
+                    />
+                  </div>
+                )}
+              </Component>
+            )}
           </div>
         </div>
       );

--- a/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
+++ b/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
@@ -131,11 +131,11 @@ const FavoritesCollectionTile = memo(
                     {formatlotStr && hasListData && formatlotStr(count)}
                   </Text>
                 )}
-                {
+                {name && (
                   <Text element="h3" className={`${baseClassName}__title`} variant={TextVariants.heading5}>
                     {name}
                   </Text>
-                }
+                )}
               </div>
               <>
                 {hasListData && isListVariant && (
@@ -229,6 +229,7 @@ const FavoritesCollectionTile = memo(
                         className={classnames(`${baseClassName}__icon`, {
                           [`${baseClassName}__icon-circle`]: !hasListData,
                         })}
+                        title="Create List"
                       />
                       <div className={`${baseClassName}__text`}>{createFirstListText}</div>
                     </div>
@@ -247,6 +248,7 @@ const FavoritesCollectionTile = memo(
                           height={iconSize}
                           color="$dark-gray"
                           className={`${baseClassName}__icon`}
+                          title="Favorites"
                         />
                         <div className={`${baseClassName}__text`}>{emptyFavoritesText}</div>
                       </div>
@@ -271,6 +273,7 @@ const FavoritesCollectionTile = memo(
                           className={classnames(`${baseClassName}__icon`, {
                             [`${baseClassName}__icon-circle`]: !hasListData,
                           })}
+                          title="Favorite"
                         />
                         <div className={`${baseClassName}__text`}>{emptyListsText}</div>
                       </div>

--- a/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
+++ b/src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx
@@ -76,6 +76,26 @@ export interface FavoritesCollectionTileProps extends ComponentProps<'div'> {
    * Custom icon size for the icon in the tile
    */
   iconSize?: number;
+  /**
+   * ARIA label for the popover menu trigger
+   */
+  menuAriaLabel?: string;
+  /**
+   * ARIA label for the create variant container
+   */
+  createAriaLabel?: string;
+  /**
+   * ARIA label for the favorites empty state
+   */
+  favoritesAriaLabel?: string;
+  /**
+   * ARIA label for the lists empty state
+   */
+  emptyListAriaLabel?: string;
+  /**
+   * ARIA label for list
+   */
+  listAriaLabel?: string;
 }
 
 /**
@@ -109,6 +129,11 @@ const FavoritesCollectionTile = memo(
         formatlotStr = (count, lotText = count === 1 ? 'LOT' : 'LOTS') => `${count} ${lotText}`,
         linkClassName,
         iconSize = 22,
+        menuAriaLabel = 'Manage List',
+        createAriaLabel = 'Create List',
+        favoritesAriaLabel = 'Favorites',
+        emptyListAriaLabel = 'Empty List',
+        listAriaLabel = 'List',
         ...props
       },
       ref,
@@ -146,7 +171,7 @@ const FavoritesCollectionTile = memo(
                         data-testid="menu-trigger"
                         tabIndex={0}
                         role="button"
-                        aria-label="Manage List"
+                        aria-label={menuAriaLabel}
                         aria-haspopup="menu"
                         onKeyDown={(event) => {
                           if (event.key === 'Enter') {
@@ -163,7 +188,6 @@ const FavoritesCollectionTile = memo(
                             height={iconSize}
                             color="$dark-gray"
                             className={`${baseClassName}__icon-button`}
-                            title="Manage List"
                           />
                         </div>
                       </div>
@@ -205,7 +229,7 @@ const FavoritesCollectionTile = memo(
                 <div
                   className={`${baseClassName}__media-container`}
                   data-testid="list"
-                  aria-label="Lists"
+                  aria-label={createAriaLabel}
                   role="button"
                   tabIndex={0}
                   onKeyDown={(e) => {
@@ -239,7 +263,11 @@ const FavoritesCollectionTile = memo(
             ) : (
               <Component href={href} className={classnames(`${baseClassName}__media-link`, linkClassName)} tabIndex={0}>
                 {isCountEmpty && variant === 'favorites' && (
-                  <div className={`${baseClassName}__media-container`} data-testid="favorites" aria-label="Favorites">
+                  <div
+                    className={`${baseClassName}__media-container`}
+                    data-testid="favorites"
+                    aria-label={favoritesAriaLabel}
+                  >
                     <div className={classnames(`${baseClassName}__empty`, `${baseClassName}__empty--bg`)}>
                       <div className={`${baseClassName}__empty__content`}>
                         <Icon
@@ -257,7 +285,11 @@ const FavoritesCollectionTile = memo(
                 )}
 
                 {isHasListAndCountEmpty && isListVariant && (
-                  <div className={`${baseClassName}__media-container`} data-testid="list" aria-label="Lists">
+                  <div
+                    className={`${baseClassName}__media-container`}
+                    data-testid="list"
+                    aria-label={emptyListAriaLabel}
+                  >
                     <div
                       className={classnames(`${baseClassName}__empty`, {
                         [`${baseClassName}__empty--create-list`]: !hasListData,
@@ -282,7 +314,7 @@ const FavoritesCollectionTile = memo(
                 )}
 
                 {!isCountEmpty && hasListData && (
-                  <div className={`${baseClassName}__media-container`} ref={imageRef}>
+                  <div className={`${baseClassName}__media-container`} ref={imageRef} aria-label={listAriaLabel}>
                     <SeldonImage
                       alt={name}
                       aspectRatio="1/1"

--- a/src/patterns/FavoritesCollectionTile/_favoritesCollectionTile.scss
+++ b/src/patterns/FavoritesCollectionTile/_favoritesCollectionTile.scss
@@ -176,11 +176,19 @@
     text-transform: none;
   }
 
-  &__create-spacing {
-    height: calc($spacing-xsm + var(--body-line-height-size3) + var(--heading-line-height-size5));
-  }
-
   [data-radix-popper-content-wrapper] > * {
     all: unset;
+  }
+
+  &__create-variant {
+    all: unset;
+    background: none;
+    height: 100%;
+    margin-top: calc($spacing-xsm + var(--body-line-height-size3) + var(--heading-line-height-size5));
+    width: 100%;
+
+    &:focus-visible {
+      outline: 1px solid $pure-black;
+    }
   }
 }

--- a/src/patterns/FavoritesCollectionTile/_favoritesCollectionTile.scss
+++ b/src/patterns/FavoritesCollectionTile/_favoritesCollectionTile.scss
@@ -109,6 +109,7 @@
   }
 
   &__media-container {
+    background-color: $soft-gray;
     position: relative;
     width: 100%;
   }

--- a/src/patterns/FavoritesCollectionTile/_favoritesCollectionTile.scss
+++ b/src/patterns/FavoritesCollectionTile/_favoritesCollectionTile.scss
@@ -147,8 +147,7 @@
   }
 
   &__icon {
-    grid-column: 1;
-    justify-self: start;
+    justify-content: flex-start;
     pointer-events: none;
 
     &-rotate {
@@ -158,7 +157,9 @@
     &-circle {
       border: 2px solid $dark-gray;
       border-radius: 50%;
-      transform: scale(0.846);
+      height: 1.5rem;
+      justify-content: flex-start;
+      width: 1.5rem;
     }
   }
 

--- a/src/patterns/FavoritesCollectionTile/_favoritesCollectionTile.scss
+++ b/src/patterns/FavoritesCollectionTile/_favoritesCollectionTile.scss
@@ -133,6 +133,7 @@
     }
 
     &--create-list {
+      background-color: $white;
       border: 1px solid #0000001f;
       border-radius: 0;
     }


### PR DESCRIPTION
**Jira ticket**

[L3-7093](https://phillipsauctions.atlassian.net/browse/L3-7093)

**Screenshots**
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/e77c371b-3567-45c6-8463-02f532f7f238) | ![image](https://github.com/user-attachments/assets/3c6f75e5-d211-46b4-b06b-898ff03893fd) |
| ![image](https://github.com/user-attachments/assets/93e16b76-0b81-4755-bda1-f4e6cb3cfdd0) | ![image](https://github.com/user-attachments/assets/d589b379-ee82-48f7-bc75-8743cf3b11b4) |

**Figma link**

[Figma Link](https://www.figma.com/design/rIefa3bRPyZbZmtyV9PSQv/My-Account?node-id=75-19784&m=dev)

**Summary**

Updating the Favorites Collection Tile for style and accessibility: 
- Background of lot object tile in favorites collection tile should be gray, object contain
- Create First List tile should be a button
- ('...' trigger that pops the Edit and Delete) popover doesn't have any good aria text

**Change List (describe the changes made to the files)**

This pull request introduces enhancements to the `FavoritesCollectionTile` component, including improved accessibility, new functionality for the "create" variant, and updates to the visual and behavioral aspects of the component. Additionally, tests and stories have been updated to reflect these changes.

### Component Enhancements:
* Added `aria-label` and `aria-haspopup` attributes for better accessibility and screen reader support in the `menu-trigger` button. (`src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx`)
* Introduced a new "create" variant with a button-like behavior, including keyboard support for `Enter` and `Space` keys. (`src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx`) [[1]](diffhunk://#diff-ef5f9ae9998e5be744bb5f26c42c47b16fdf499f892b11f4c5ee472b7c09e981R202-R238) [[2]](diffhunk://#diff-ef5f9ae9998e5be744bb5f26c42c47b16fdf499f892b11f4c5ee472b7c09e981L217-L243)
* Updated the image rendering behavior to use `objectFit="contain"` instead of `cover` for better visual consistency. (`src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.tsx`)

### Test Updates:
* Added tests for the "create" variant to ensure correct rendering, accessibility attributes, and `onClick` behavior when interacting with the button. (`src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.test.tsx`)
* Updated an existing test to use the "create" variant instead of "lists" for a blank list scenario. (`src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.test.tsx`)

### Story Updates:
* Updated the `Playground` story to use a new placeholder image URL. (`src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.stories.tsx`)
* Added an `onClick` handler to the "create" variant story to demonstrate the new functionality. (`src/patterns/FavoritesCollectionTile/FavoritesCollectionTile.stories.tsx`)

### Styling Improvements:
* Added a soft gray background color to the media container for better visual distinction. (`src/patterns/FavoritesCollectionTile/_favoritesCollectionTile.scss`)

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-7093]: https://phillipsauctions.atlassian.net/browse/L3-7093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ