### PR TITLE
feat(Modal): PHOENIX-2058 adding custom icon to modal

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -7,6 +7,7 @@ import Drawer from '../Drawer/Drawer';
 import { TextVariants } from '../Text';
 import Text from '../Text/Text';
 import Modal from './Modal';
+import { Icon } from '../Icon';
 
 const meta = {
   title: 'Components/Modal',
@@ -79,6 +80,36 @@ export const ModalFromDrawer = () => {
           <input type="text" placeholder="Input field 2" />
           <Button onClick={closeModal}>Close Modal</Button>
         </div>
+      </Modal>
+    </>
+  );
+};
+
+export const CustomCloseIcon = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onClose = () => {
+    setIsOpen(false);
+  };
+
+  const onOpen = () => {
+    setIsOpen(true);
+  };
+
+  return (
+    <>
+      <Button className={`modal-story__button`} onClick={onOpen}>
+        Open Modal
+      </Button>
+
+      <PlaygroundSplitPanel />
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        closeIcon={<Icon icon="ChevronLeft" height={32} width={32} color="currentColor" />}
+        closeIconPosition="left"
+      >
+        <img src="https://www.dev.phillips.com/Content/homepage/wechat_qr_mobile.png" alt="placeholder" />
       </Modal>
     </>
   );

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { runCommonTests } from '../../utils/testUtils';
 import Modal from './Modal';
 import { ModalFromDrawer } from './Modal.stories';
+import { px } from '../../utils';
 
 describe('Modal', () => {
   const onCloseMock = vi.fn();
@@ -86,5 +87,43 @@ describe('Modal', () => {
     const overlay = screen.getByTestId(/overlay/);
     await userEvent.click(overlay);
     expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it('renders custom close icon', () => {
+    const customCloseIcon = <span>Custom Close</span>;
+    render(
+      <Modal isOpen onClose={onCloseMock} closeIcon={customCloseIcon} closeIconPosition="left">
+        <div>Modal Content</div>
+      </Modal>,
+    );
+
+    const closeButton = screen.getByText('Custom Close');
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  it('renders class to align close icon to the left', () => {
+    const customCloseIcon = <span>Custom Close</span>;
+    render(
+      <Modal isOpen onClose={onCloseMock} closeIcon={customCloseIcon} closeIconPosition="left">
+        <div>Modal Content</div>
+      </Modal>,
+    );
+
+    const closeButton = screen.getByText('Custom Close');
+    expect(closeButton).toBeInTheDocument();
+    expect(closeButton.parentElement).toHaveClass(`${px}-modal__close--left`);
+  });
+
+  it('renders component without left class alignment', () => {
+    const customCloseIcon = <span>Custom Close</span>;
+    render(
+      <Modal isOpen onClose={onCloseMock} closeIcon={customCloseIcon}>
+        <div>Modal Content</div>
+      </Modal>,
+    );
+
+    const closeButton = screen.getByText('Custom Close');
+    expect(closeButton).toBeInTheDocument();
+    expect(closeButton.parentElement).not.toHaveClass(`${px}-modal__close--left`);
   });
 });

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -36,6 +36,14 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement>, Dialog
    * Content label for accessibility
    */
   contentLabel?: string;
+  /**
+   * Custom close icon
+   */
+  closeIcon?: React.ReactElement;
+  /**
+   * Position of the close icon
+   */
+  closeIconPosition?: 'left' | 'right';
 }
 
 /**
@@ -45,7 +53,21 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement>, Dialog
  *
  */
 const Modal = forwardRef<HTMLDivElement, ModalProps>(
-  ({ children, className, overlayClassName, isOpen = false, onClose = noOp, style, contentLabel, ...props }, ref) => {
+  (
+    {
+      children,
+      className,
+      overlayClassName,
+      isOpen = false,
+      onClose = noOp,
+      style,
+      contentLabel,
+      closeIcon = <Icon icon="CloseX" height={32} width={32} color="currentColor" />,
+      closeIconPosition = 'right',
+      ...props
+    },
+    ref,
+  ) => {
     const { className: baseClassName, 'data-testid': testId, ...commonProps } = getCommonProps(props, 'Modal');
 
     return (
@@ -77,10 +99,12 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
               <IconButton
                 id="modal-close-button"
                 aria-label="Close Modal"
-                className={classnames(`${baseClassName}__close`)}
+                className={classnames(`${baseClassName}__close`, {
+                  [`${baseClassName}__close--left`]: closeIconPosition === 'left',
+                })}
                 variant={ButtonVariants.tertiary}
               >
-                <Icon icon="CloseX" height={32} width={32} color="currentColor" />
+                {closeIcon}
               </IconButton>
             </Dialog.Close>
             {children}

--- a/src/components/Modal/_modal.scss
+++ b/src/components/Modal/_modal.scss
@@ -12,6 +12,11 @@
   transform: translate(-50%, -50%);
   z-index: 30;
 
+  &__close--left {
+    left: 0.4rem;
+    right: auto;
+  }
+
   &__overlay {
     background-color: $overlay-black;
     inset: 0;


### PR DESCRIPTION
**Jira ticket**

[PHOENIX-2058](https://phillipsauctions.atlassian.net/browse/PHOENIX-2058)

**Screenshots**
| Before | After |
| ------ | ----- |
| <img width="300" height="318" alt="Screenshot 2025-07-22 at 10 49 03 PM" src="https://github.com/user-attachments/assets/0208d45d-f250-4f6e-9048-f0734cdc3c98" /> | <img width="376" height="386" alt="Screenshot 2025-07-22 at 10 48 09 PM" src="https://github.com/user-attachments/assets/70599310-5109-47fe-b668-7b242fdaddb4" /> |

**Figma link**

[Figma Link](https://www.figma.com/board/XLadic4iRNVzGE8JP3XGjZ/Overview-of-Mobile-Bidding-Changes-11Mar2025?node-id=4-18700&t=4xNFA883EsffV6h0-4)

**Summary**

Added close icon prop and positioning

**Change List (describe the changes made to the files)**

This pull request introduces a new feature for the `Modal` component: support for a customizable close icon and the ability to position it on the left or right. It includes updates to the component's implementation, tests, and styling, as well as an example in the storybook.

### New Feature: Customizable Close Icon
* Added `closeIcon` and `closeIconPosition` props to the `Modal` component, allowing users to customize the close icon and position it either on the left or right. Default values are provided for backward compatibility. (`src/components/Modal/Modal.tsx`: [[1]](diffhunk://#diff-766208c965d34c3bf67b6cf8dc749036c694359ca121365e8e7e27c08454383eR39-R46) [[2]](diffhunk://#diff-766208c965d34c3bf67b6cf8dc749036c694359ca121365e8e7e27c08454383eL48-R70)
* Updated the `Modal` implementation to apply the `closeIcon` and conditionally add a CSS class for left-aligned icons. (`src/components/Modal/Modal.tsx`: [src/components/Modal/Modal.tsxL80-R107](diffhunk://#diff-766208c965d34c3bf67b6cf8dc749036c694359ca121365e8e7e27c08454383eL80-R107))

### Storybook Example
* Added a new story, `CustomCloseIcon`, to demonstrate the use of a custom close icon and left alignment. (`src/components/Modal/Modal.stories.tsx`: [[1]](diffhunk://#diff-eaa17bba432b3a3907d972a2dbf354a547d67894f2d90579513723595142ae1dR10) [[2]](diffhunk://#diff-eaa17bba432b3a3907d972a2dbf354a547d67894f2d90579513723595142ae1dR87-R116)

### Tests for Custom Close Icon
* Added unit tests to verify rendering of the custom close icon, alignment to the left, and default behavior when no alignment is specified. (`src/components/Modal/Modal.test.tsx`: [src/components/Modal/Modal.test.tsxR91-R128](diffhunk://#diff-982520c224dfd6dc91a509dccdbe4f669b2e97cdb0eb927e38ed7e9c8b41c57cR91-R128))

### Styling Updates
* Added a new CSS class, `__close--left`, to support left-aligned close icons. (`src/components/Modal/_modal.scss`: [src/components/Modal/_modal.scssR15-R19](diffhunk://#diff-6d76f4bdad8d0d8e0d51c033a3c25a7c762b885ea07d202a0cc56763efdc2e05R15-R19))
**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[PHOENIX-2058]: https://phillipsauctions.atlassian.net/browse/PHOENIX-2058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ