### PR TITLE
fix(drawer): L3-7407 explicitly unset pointer-events

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -84,6 +84,8 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
         open={isOpen}
         onOpenChange={(open) => {
           if (!open) {
+            // this is a workaround because Drawers interacting with other dialogs can get confused and not clear pointer-events correctly https://my.onetrust.com/s/case/500RO00000XuZl3/pointerevents-none-being-applied-incorrectly-by-manage-cookies-dialog
+            document.body.style.removeProperty('pointer-events');
             onClose();
           }
         }}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -74,7 +74,11 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
       <Dialog.Root
         open={isOpen}
         onOpenChange={(open) => {
-          if (!open) onClose();
+          if (!open) {
+            // this is a workaround because Dialogs interacting with other dialogs can get confused and not clear pointer-events correctly. https://my.onetrust.com/s/case/500RO00000XuZl3/pointerevents-none-being-applied-incorrectly-by-manage-cookies-dialog
+            document.body.style.removeProperty('pointer-events');
+            onClose();
+          }
         }}
       >
         <Dialog.Portal>


### PR DESCRIPTION
**Jira ticket**

[L3-7407](https://phillipsauctions.atlassian.net/browse/L3-7407)

Workaround for this issue here:

https://github.com/user-attachments/assets/613ae026-a3d8-40a1-80d7-625fc7e288a5



**Summary**

Unfortunately due to probably a race condition, the removal of the `pointer-events:none` body when closing a modal or drawer doesn't always happen in time and can causes issues with other dialogs popping afterwards.  This change makes it happen before closing the drawer at all.

**Change List (describe the changes made to the files)**



**Acceptance Test (how to verify the PR)**

- Build this seldon and copy the `/dist` directory over top of your `phillips-public-remix/node_modules/@phillips/seldon so it uses this one
- Checkout this remix branch `L3-7407-cookie-banner`
- Follow those steps in the video above:\
Onetrust Cookie banner is showing
Pop up our Footer Subscribe drawer (which sets pointer-events:none) on the root
Pop up the Manage Cookies dialog from the OneTrust banner.
Interact with it in a way that closes the Manage Cookies dialog (close or accept)
Now the site has a pointer-events: none attached to it and can no longer be clicked on

**Regression Test**

- Verify other drawers and Modals in the Remix site

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-7407]: https://phillipsauctions.atlassian.net/browse/L3-7407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ