### PR TITLE
feat(SaleCard): L3-7429 make sale card more responsive

### DIFF
--- a/src/patterns/SaleCard/SaleCard.stories.tsx
+++ b/src/patterns/SaleCard/SaleCard.stories.tsx
@@ -21,7 +21,7 @@ export const SaleCardPlayground = (props: SaleCardProps) => (
 );
 
 const defaultProps = {
-  imageSrc: 'https://picsum.photos/160/90',
+  imageSrc: 'https://picsum.photos/800/450',
   auctionType: 'Live Auction',
   titleText: 'Modern & Contemporary Art Day Sale, Morning Session',
   date: '2 PM EST, May 27, 2025',
@@ -176,7 +176,7 @@ export const SaleCardWithPrimaryCTA = () => (
 
 export const SaleCardWithSecondaryCTA = () => (
   <SaleCard
-    imageSrc="https://picsum.photos/160/90"
+    imageSrc="https://picsum.photos/800/450"
     auctionType="Live Auction"
     titleText="Modern & Contemporary Art Day Sale, Morning Session"
     date="2 PM EST, May 27, 2025"
@@ -227,7 +227,7 @@ export const SaleCardWithDownloadLink = () => (
 
 export const SaleCardNoCTA = () => (
   <SaleCard
-    imageSrc="https://picsum.photos/160/90"
+    imageSrc="https://picsum.photos/800/450"
     auctionType="Live Auction"
     titleText="Modern & Contemporary Art Day Sale, Morning Session"
     date="2 PM EST, May 27, 2025"

--- a/src/patterns/SaleCard/SaleCard.tsx
+++ b/src/patterns/SaleCard/SaleCard.tsx
@@ -102,8 +102,11 @@ const SaleCard = forwardRef<HTMLDivElement, SaleCardProps>(
             )}
           </div>
         </div>
-        {variant !== SaleCardVariants.RELATED_SALE_TILE && (
-          <SSRMediaQuery.Media greaterThanOrEqual="md">{children}</SSRMediaQuery.Media>
+
+        {variant !== SaleCardVariants.RELATED_SALE_TILE && !!children && (
+          <div className={`${baseClassName}__ctas`}>
+            <SSRMediaQuery.Media greaterThanOrEqual="md">{children}</SSRMediaQuery.Media>
+          </div>
         )}
       </article>
     );

--- a/src/patterns/SaleCard/SaleCard.tsx
+++ b/src/patterns/SaleCard/SaleCard.tsx
@@ -103,7 +103,7 @@ const SaleCard = forwardRef<HTMLDivElement, SaleCardProps>(
           </div>
         </div>
 
-        {variant !== SaleCardVariants.RELATED_SALE_TILE && !!children && (
+        {variant !== SaleCardVariants.RELATED_SALE_TILE && children && (
           <div className={`${baseClassName}__ctas`}>
             <SSRMediaQuery.Media greaterThanOrEqual="md">{children}</SSRMediaQuery.Media>
           </div>

--- a/src/patterns/SaleCard/_saleCard.scss
+++ b/src/patterns/SaleCard/_saleCard.scss
@@ -20,7 +20,6 @@
     min-width: 100%;
 
     @include media($breakpoint-md) {
-      aspect-ratio: 107/60;
       min-width: auto;
     }
 
@@ -40,6 +39,14 @@
 
     @include media($size-md, 'max') {
       align-self: flex-start;
+    }
+  }
+
+  &__ctas {
+    flex: 0 0 191px;
+
+    @include media($breakpoint-lg) {
+      flex-basis: 280px;
     }
   }
 

--- a/src/patterns/SaleCard/_saleCard.scss
+++ b/src/patterns/SaleCard/_saleCard.scss
@@ -43,7 +43,11 @@
   }
 
   &__ctas {
-    flex: 0 0 191px;
+    flex: 0 0 0%;
+
+    @include media($breakpoint-md) {
+      flex-basis: 191px;
+    }
 
     @include media($breakpoint-lg) {
       flex-basis: 280px;


### PR DESCRIPTION
**Jira ticket**

[L3-7429](https://phillipsauctions.atlassian.net/browse/L3-7429)



**Figma link**

[Figma Link](https://www.figma.com/design/H1kCh6MXU8jasYbQuCbyBt/Calendar?node-id=5470-51467&m=dev)

**Summary**

Updates the SaleCard to be more responsive and rely on flexbox for sizing the image and detail sections


**Change List (describe the changes made to the files)**

This pull request updates the `SaleCard` component and its related stories to improve image quality, adjust conditional rendering for CTAs, and add styling for CTA containers. The most significant changes are grouped below:

**Image quality improvements in storybook examples:**

* Updated the `imageSrc` in all `SaleCard` story variants to use a higher-resolution image (`https://picsum.photos/800/450` instead of `https://picsum.photos/160/90`), ensuring better image quality in storybook previews. [[1]](diffhunk://#diff-7e0ceeccfbddbc24ab0c53e8dce72b8a52a957592386628ffbdb952bdf648deeL24-R24) [[2]](diffhunk://#diff-7e0ceeccfbddbc24ab0c53e8dce72b8a52a957592386628ffbdb952bdf648deeL179-R179) [[3]](diffhunk://#diff-7e0ceeccfbddbc24ab0c53e8dce72b8a52a957592386628ffbdb952bdf648deeL230-R230)

**Component rendering logic:**

* Modified the `SaleCard` component to only render the CTA container if there are children present, preventing empty CTA sections from being displayed.

**Styling and layout adjustments:**

* Added a new `__ctas` class with responsive flex-basis styling for the CTA container, improving layout consistency across screen sizes.
* Removed the `aspect-ratio` property from the image container for medium breakpoints, likely to allow for more flexible image sizing.
<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-7429]: https://phillipsauctions.atlassian.net/browse/L3-7429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ