### PR TITLE
feat(Carousel): PHOENIX-2082 added a11 fixes

### DIFF
--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -207,12 +207,18 @@ export const CarouselWithMultipleItems = (props: CarouselProps) => {
 
   return (
     <div>
-      <Carousel {...{ ...props, slidesToScroll: props.slidesToScroll ?? 1 }}>
+      <Carousel {...{ ...props }}>
         <CarouselContent>
           {array.map((el) => (
             <CarouselItem
+              onClick={() => alert(el)}
+              onKeyDown={(e) => {
+                if (e.keyCode == 13) {
+                  alert(el);
+                }
+              }}
               style={{
-                maxWidth: `calc(${100 / (props.slidesToScroll ?? 1)}% - 2%)`,
+                maxWidth: `18%`,
                 minWidth: 0,
                 flex: '0 0 100%',
                 border: array[0] === el ? '1px solid blue' : '1px solid #eee',
@@ -222,6 +228,7 @@ export const CarouselWithMultipleItems = (props: CarouselProps) => {
                 marginRight: '16px',
               }}
               key={el}
+              tabIndex={0}
             >
               <img style={{ width: '60px', height: '60px' }} src={`https://picsum.photos/60/60?random=${el}`} alt="" />
               <div>
@@ -242,7 +249,7 @@ export const CarouselWithMultipleItems = (props: CarouselProps) => {
   );
 };
 
-CarouselWithMultipleItems.args = { disableNavigationDrag: 'desktop', slidesToScroll: 5 } satisfies CarouselProps;
+CarouselWithMultipleItems.args = { disableNavigationDrag: 'desktop' } satisfies CarouselProps;
 CarouselWithMultipleItems.argTypes = {
   slidesToScroll: {
     control: {

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -42,10 +42,6 @@ export interface CarouselProps extends ComponentProps<'div'> {
    *  The threshold for slides to be considered in view. A value of 0.1 means that 10% of the slide must be in view for it to be considered in view.
    */
   inViewThreshold?: number;
-  /**
-   * The number of slides to scroll at once.
-   */
-  slidesToScroll?: number;
 }
 
 type CarouselContextProps = {
@@ -87,7 +83,6 @@ const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
       disableDrag = false,
       disableNavigationDrag = null,
       inViewThreshold = 0.99,
-      slidesToScroll = 1,
       ...props
     },
     ref,
@@ -114,7 +109,6 @@ const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
         startIndex,
         inViewThreshold,
         ...disableNavigationDragBreakpoint,
-        slidesToScroll,
       },
       [
         ...(useWheelGestures
@@ -147,9 +141,22 @@ const Carousel = forwardRef<HTMLDivElement, CarouselProps>(
         if (event.key === 'ArrowLeft') {
           event.preventDefault();
           api?.scrollPrev();
+
+          const prevNode = api?.slideNodes().filter((el) => el === document.activeElement)[0]
+            ?.previousElementSibling as HTMLElement;
+
+          if (prevNode) {
+            prevNode?.focus();
+          }
         } else if (event.key === 'ArrowRight') {
           event.preventDefault();
           api?.scrollNext();
+          const nextNode = api?.slideNodes().filter((el) => el === document.activeElement)[0]
+            ?.nextElementSibling as HTMLElement;
+
+          if (nextNode) {
+            nextNode?.focus();
+          }
         }
       },
       [api],

--- a/src/components/Carousel/CarouselArrows.test.tsx
+++ b/src/components/Carousel/CarouselArrows.test.tsx
@@ -10,6 +10,7 @@ vi.mock('./utils', () => ({
 describe('CarouselArrows', () => {
   const mockScrollPrev = vi.fn();
   const mockScrollNext = vi.fn();
+  const mockScrollTo = vi.fn();
 
   beforeEach(() => {
     (useCarousel as Mock).mockReturnValue({
@@ -31,12 +32,18 @@ describe('CarouselArrows', () => {
   });
 
   it('calls scrollPrev on prev arrow click', () => {
+    (useCarousel as Mock).mockReturnValue({
+      api: { slidesInView: () => [0], scrollPrev: mockScrollPrev, scrollNext: mockScrollNext },
+    });
     render(<CarouselArrows />);
     fireEvent.click(screen.getByTestId('prev-arrow'));
     expect(mockScrollPrev).toHaveBeenCalledWith(true);
   });
 
   it('calls scrollNext on next arrow click', () => {
+    (useCarousel as Mock).mockReturnValue({
+      api: { slidesInView: () => [0], scrollPrev: mockScrollPrev, scrollNext: mockScrollNext },
+    });
     render(<CarouselArrows />);
     fireEvent.click(screen.getByTestId('next-arrow'));
     expect(mockScrollNext).toHaveBeenCalledWith(true);
@@ -54,5 +61,33 @@ describe('CarouselArrows', () => {
     render(<CarouselArrows />);
     fireEvent.click(screen.getByTestId('next-arrow'));
     expect(mockScrollNext).not.toHaveBeenCalled();
+  });
+
+  it('scrolls to previous page when multiple slides are in view for prev arrow', () => {
+    (useCarousel as Mock).mockReturnValue({
+      api: {
+        slidesInView: () => [2, 3, 4],
+        scrollPrev: mockScrollPrev,
+        scrollNext: mockScrollNext,
+        scrollTo: mockScrollTo,
+      },
+    });
+    render(<CarouselArrows />);
+    fireEvent.click(screen.getByTestId('prev-arrow'));
+    expect(mockScrollTo).toHaveBeenCalledWith(-1);
+  });
+
+  it('scrolls to next page when multiple slides are in view for next arrow', () => {
+    (useCarousel as Mock).mockReturnValue({
+      api: {
+        slidesInView: () => [2, 3, 4],
+        scrollPrev: mockScrollPrev,
+        scrollNext: mockScrollNext,
+        scrollTo: mockScrollTo,
+      },
+    });
+    render(<CarouselArrows />);
+    fireEvent.click(screen.getByTestId('next-arrow'));
+    expect(mockScrollTo).toHaveBeenCalledWith(5);
   });
 });

--- a/src/components/Carousel/CarouselArrows.tsx
+++ b/src/components/Carousel/CarouselArrows.tsx
@@ -17,12 +17,24 @@ const CarouselArrows = forwardRef<HTMLDivElement, CarouselArrowsProps>(({ classN
   const { api } = useCarousel();
   const onPrevArrowClick = useCallback(() => {
     if (!api) return;
-    api.scrollPrev(true);
+    if (api?.slidesInView().length <= 1) {
+      api.scrollPrev(true);
+    } else {
+      const slidesInView = api?.slidesInView();
+      api?.scrollTo(slidesInView[0] - (slidesInView.length ?? 1));
+    }
   }, [api]);
 
   const onNextArrowClick = useCallback(() => {
     if (!api) return;
-    api.scrollNext(true);
+
+    if (api?.slidesInView().length <= 1) {
+      api?.scrollNext(true);
+    } else {
+      const slidesInView = api?.slidesInView();
+      const lastSlideInView = slidesInView.slice(-1)[0] + 1;
+      api?.scrollTo(lastSlideInView);
+    }
   }, [api]);
 
   return (

--- a/src/components/Carousel/CarouselKeyboardNavigation.test.tsx
+++ b/src/components/Carousel/CarouselKeyboardNavigation.test.tsx
@@ -13,6 +13,11 @@ const mockApi = vi.hoisted(() => ({
   off: vi.fn(() => ({ off: vi.fn(() => ({ off: vi.fn(() => ({ off: vi.fn() })) })) })),
   reInit: vi.fn(),
   slidesInView: () => [0],
+  slideNodes: () => [
+    <CarouselItem key="slide-1">Slide 1</CarouselItem>,
+    <CarouselItem key="slide-2">Slide 2</CarouselItem>,
+    <CarouselItem key="slide-3">Slide 3</CarouselItem>,
+  ],
   scrollSnapList: () => [0],
   selectedScrollSnap: () => true,
 }));


### PR DESCRIPTION
**Jira ticket**

[PHOENIX-2082](https://phillipsauctions.atlassian.net/browse/PHOENIX-2082)

**Screenshots**
NO VISUAL CHANGES

**Summary**

Added some a11 fixes, updated arrow navigation

**Change List (describe the changes made to the files)**

- removed `slidesToScroll` and added `slidesInView` based scroll. The amount of slides you scroll will be determined by the amount of slides you have in current view. If you have `1 to 3` slides in view, clicking on the next slide button will bring you to `3 to 6` slides
- when you use `tab` and just focuses on carousel you be focuses on first item, you can use arrow next or just tab to go to second item, carousel will move just one step to make focused item first. The way we were doing it before: we didn't have focus at all, on arrow next we were moving the whole slides in view (from `1 to 3` to `3 to 6`) which is wrong, we wan't people to have ability to go through each individual lot with arrows and be able to open it vs just looking at it

**Acceptance Test (how to verify the PR)**

- go to /?path=/story/components-carousel--carousel-with-multiple-items
- verify you can tab to when first item in focus
- verify that when you tab next sibling is in focus
- verify when you use arrows next or prev sibling is in focus
- verify that carousel still scrolls the full width of current view (in story it's 1 to 5 and next slide is 6 to 10)

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
