### PR TITLE
feat(colorTokens): L3-7655 add new token for no reserve red contrast violation

### DIFF
--- a/src/design/colors-tokens/ColorTokensPage.tsx
+++ b/src/design/colors-tokens/ColorTokensPage.tsx
@@ -108,7 +108,9 @@ const coreColorSections = [
         colors: [
           { label: '$success-default', hex: '#00cc39' },
           { label: '$warning-default', hex: '#ea0404' },
+          { label: '$reserve-bid', hex: '#B00000' },
           { label: '$focus-default', hex: '#0077CC' },
+          { label: '$status-info', hex: '#0065fc' },
         ],
       },
     ],
@@ -183,6 +185,7 @@ const semanticColorSections = [
         colors: [
           { label: '$success-default', hex: '#00cc39' },
           { label: '$warning-default', hex: '#ea0404' },
+          { label: '$reserve-bid', hex: '#B00000' },
           { label: '$focus-default', hex: '#0077CC' },
           { label: '$status-info', hex: '#0065fc' },
         ],

--- a/src/scss/_vars.scss
+++ b/src/scss/_vars.scss
@@ -60,6 +60,7 @@ $bg-overlay: rgba(0, 0, 0, 50%);
 // Status
 $success-default: #00cc39;
 $warning-default: #ea0404;
+$reserve-bid: #b00000;
 $status-info: #0065fc;
 $focus-default: #07c;
 


### PR DESCRIPTION
**Jira ticket**

[L3-7655](https://phillipsauctions.atlassian.net/browse/L3-7655)

**Screenshots**
<img width="1078" height="676" alt="image" src="https://github.com/user-attachments/assets/9bf86e3f-1c51-4597-8f23-ec0bdbfba793" />

**Figma link**

n/a

**Summary**

- The new highlight-red, when used for no reserve text on lot placard, created a contrast violation
- This PR adds in a darker red to pass checks
- The actual component is in remix

**Change List (describe the changes made to the files)**

This pull request adds a new color token for "reserve bid" to both the design color tokens page and the SCSS variables, as well as ensures it appears in both the core and semantic color sections. These changes help maintain consistency between the design system documentation and the SCSS codebase.

**Design token additions:**

* Added `$reserve-bid` color token (`#B00000`) to the `coreColorSections` and `semanticColorSections` arrays in `ColorTokensPage.tsx` to display it in the design tokens documentation. [[1]](diffhunk://#diff-2128f4b6f00b9cf652e7d322d9b918f1ea911a9cffab2f4cf630a6f63be705ebR111-R113) [[2]](diffhunk://#diff-2128f4b6f00b9cf652e7d322d9b918f1ea911a9cffab2f4cf630a6f63be705ebR188)

**SCSS variable update:**

* Defined `$reserve-bid: #b00000;` in `_vars.scss` to make the new color available for styling throughout the codebase.

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-7655]: https://phillipsauctions.atlassian.net/browse/L3-7655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ