### PR TITLE
fix(drawer): L3-7876 - added z index to close button

### DIFF
--- a/src/components/Drawer/_drawer.scss
+++ b/src/components/Drawer/_drawer.scss
@@ -34,6 +34,7 @@
     position: absolute;
     right: 10px;
     top: 10px;
+    z-index: 10;
   }
 
   &__overlay {


### PR DESCRIPTION
**Jira ticket**

[L3-7876](https://phillipsauctions.atlassian.net/browse/L3-7876)

This pull request makes a small styling improvement to the Drawer component. The change increases the stacking order of the Drawer close button to ensure it appears above other elements.

* Added `z-index: 10;` to the `.Drawer__close` class in `src/components/Drawer/_drawer.scss` to fix overlay and visibility issues.

You can test this by opening up the preview on your phone. You should be able to remove the header text from the story and then still be able to close the modal. In prod, doing the same thing will not allow you to close the modal. 

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-7876]: https://phillipsauctions.atlassian.net/browse/L3-7876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ