### PR TITLE
fix(Filter): L3-8050 Filter Option Cut Off Horizontally in Center of Word

### DIFF
--- a/src/patterns/FiltersInline/_filterDropdownMenu.scss
+++ b/src/patterns/FiltersInline/_filterDropdownMenu.scss
@@ -125,8 +125,8 @@ $dropdown-height: 240px;
       align-items: center;
       display: flex;
       flex-direction: row;
-      height: 2rem;
       justify-content: space-between;
+      max-height: 2rem;
     }
 
     &__label {
@@ -145,7 +145,7 @@ $dropdown-height: 240px;
 }
 
 .#{$px}-filter-dropdown-menu .#{$px}-filter-input__input__wrapper {
-  min-height: 2rem;
+  max-height: 2rem;
 }
 
 .#{$px}-filter-drawer-mobile {


### PR DESCRIPTION
**Jira ticket**

[L3-8050](https://phillipsauctions.atlassian.net/browse/L3-8050)

Updated Filter dropdown styles based on Figma.
Except the font-size for label, new token size once added will match the Figma, but not in the PR.

**Screenshots**

<img width="453" height="399" alt="Screenshot 2025-10-28 130327" src="https://github.com/user-attachments/assets/6ad018a8-d55c-4edd-87ba-892dc3f49d56" />
<img width="402" height="250" alt="Screenshot 2025-10-28 130333" src="https://github.com/user-attachments/assets/2087bb6d-cd33-4cc6-933a-e504ee849748" />
<img width="403" height="341" alt="Screenshot 2025-10-28 130336" src="https://github.com/user-attachments/assets/c7be423c-13fd-4ed8-a95f-8ce04eac0e86" />
<img width="411" height="383" alt="Screenshot 2025-10-28 130347" src="https://github.com/user-attachments/assets/da07389d-902c-4e54-ba98-cf8469ab709d" />
<img width="520" height="455" alt="Screenshot 2025-10-28 144700" src="https://github.com/user-attachments/assets/420874b1-5871-4020-ae4a-9d70c1c10ab8" />


**Figma link**

https://www.figma.com/design/hMu9IWH5N3KamJy8tLFdyV/Design-System--Foundations?node-id=24767-4652&p=f&m=dev

**Summary**


This pull request updates the desktop filter dropdown menu UI to improve spacing, add a divider, and standardize element heights. The changes affect both the React component and its associated SCSS styles, resulting in a cleaner and more consistent layout.

**UI Improvements:**

* Added a divider between the filter list and button area in the `FilterDropdownMenuDesktop` component for clearer visual separation.
* Adjusted padding, gap, and max-height values in the filter dropdown menu for improved spacing and usability, including more precise control over filter list and button wrap areas. [[1]](diffhunk://#diff-f84a34807c392456aac3d71f74bdbfeec5674e1f996a169c90725959b35c1c7cL10-R29) [[2]](diffhunk://#diff-f84a34807c392456aac3d71f74bdbfeec5674e1f996a169c90725959b35c1c7cR40)

**Style Consistency:**

* Standardized the height of filter input wrappers and relevant button areas to 32px for visual alignment. [[1]](diffhunk://#diff-f84a34807c392456aac3d71f74bdbfeec5674e1f996a169c90725959b35c1c7cR126) [[2]](diffhunk://#diff-f84a34807c392456aac3d71f74bdbfeec5674e1f996a169c90725959b35c1c7cR145-R148)

**Change List (describe the changes made to the files)**

- Additions, Changes, and Removals. (You can use [GitHub Copilot PR Summary](https://docs.github.com/en/enterprise-cloud@latest/copilot/using-github-copilot/using-github-copilot-for-pull-requests/creating-a-pull-request-summary-with-github-copilot) to populate this section)

**Acceptance Test (how to verify the PR)**

- Add step by step instructions on how to verify the change

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-8050]: https://phillipsauctions.atlassian.net/browse/L3-8050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ