### PR TITLE
feat(header): L3-7279 at large breakpoints headers were misaligned

### DIFF
--- a/src/components/Navigation/NavigationItem/_navigationItem.scss
+++ b/src/components/Navigation/NavigationItem/_navigationItem.scss
@@ -6,8 +6,6 @@
   }
 
   & .#{$px}-link--linkStylised {
-    line-height: 1.25rem;
-
     @include media($breakpoint-md) {
       padding: 0.5rem 0.625rem calc(0.5rem + 2px); // 1 px so that the bottom border of the nav counts as part of the button
       position: relative;


### PR DESCRIPTION
**Jira ticket**

[L3-7279](https://phillipsauctions.atlassian.net/browse/L3-7279)

**Screenshots**
| Before | After |
| ------ | ----- |
| <img width="1874" height="183" alt="image" src="https://github.com/user-attachments/assets/5df7f86a-6cc6-4f72-8856-8551ad4b47d6" /> | <img width="2179" height="267" alt="image" src="https://github.com/user-attachments/assets/9bc32270-4423-4fa2-a3ce-59df879db91b" />|

**Summary**

Small alignment issue with the header menu options at large breakpoint

**Acceptance Test (how to verify the PR)**

- Verify the header at all breakpoints

**Regression Test**

- (Optional) Add verification steps to make sure this PR doesn't break old functionality

**Evidence of testing**

- Post logs, screenshots, etc

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
