### PR TITLE
fix(chromatic): L3-0000 hide dynamic components from chromatic snapshots

### DIFF
--- a/src/components/Countdown/Countdown.tsx
+++ b/src/components/Countdown/Countdown.tsx
@@ -113,6 +113,7 @@ const Countdown = forwardRef<HTMLDivElement, CountdownProps>(
 
     return showTimer ? (
       <div
+        data-chromatic="ignore"
         {...commonProps}
         className={classnames(baseClassName, className, {
           [`${baseClassName}--compact`]: variant === CountdownVariants.compact,

--- a/src/components/SeldonImage/SeldonImage.tsx
+++ b/src/components/SeldonImage/SeldonImage.tsx
@@ -143,6 +143,7 @@ const SeldonImage = memo(
 
       return (
         <div
+          data-chromatic="ignore" // to handle the issue where the image is not rendered in the storybook
           ref={ref}
           className={classnames(baseClassName, className, {
             [`${baseClassName}--aspect-ratio-${aspectRatio.replace('/', '-')}`]: aspectRatio !== 'none',


### PR DESCRIPTION
Small change to exclude dynamic components that show dates and times and may not have images loaded yet from Chromatic snapshot diffs, I tested this in Remix, it's hard to test here without pulling this in over there.  More information here: 
https://www.chromatic.com/docs/ignoring-elements/#ignoring-elements-inline