### PR TITLE
feat(a11y): L3-12633 remove inaccurate default tab container label, require on…

### DIFF
--- a/src/assets/formatted/Paddle.tsx
+++ b/src/assets/formatted/Paddle.tsx
@@ -10,43 +10,41 @@ interface PaddleProps extends React.HTMLAttributes<SVGSVGElement> {
 }
 
 const Paddle = memo(
-  forwardRef < SVGSVGElement,
-  PaddleProps >
-    ((inlineProps, ref) => {
-      const { color, height, width, title, titleId: propsTitleId } = inlineProps;
-      const titleId = propsTitleId || kebabCase(title || '');
-      const hasAccessibleName = Boolean(title || inlineProps['aria-label']);
-      const props = hasAccessibleName
-        ? inlineProps
-        : {
-            ...inlineProps,
-            'aria-hidden': true,
-            role: 'presentation',
-          };
+  forwardRef<SVGSVGElement, PaddleProps>((inlineProps, ref) => {
+    const { color, height, width, title, titleId: propsTitleId } = inlineProps;
+    const titleId = propsTitleId || kebabCase(title || '');
+    const hasAccessibleName = Boolean(title || inlineProps['aria-label']);
+    const props = hasAccessibleName
+      ? inlineProps
+      : {
+          ...inlineProps,
+          'aria-hidden': true,
+          role: 'presentation',
+        };
 
-      return (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          height={height}
-          width={width}
-          role="img"
-          ref={ref}
-          aria-labelledby={titleId}
-          {...props}
-        >
-          {title ? <title id={titleId}>{title}</title> : null}
-          <path fill="#fff" d="M0 0h24v24H0z" />
-          <path
-            stroke={color}
-            strokeWidth={2}
-            d="M12 3c1.7 0 3.483.638 4.83 1.704C18.17 5.768 19 7.187 19 8.74c0 1.554-.83 2.978-2.173 4.047C15.48 13.858 13.698 14.5 12 14.5c-1.7 0-3.482-.64-4.828-1.708C5.829 11.726 5 10.304 5 8.75s.829-2.976 2.172-4.042C8.518 3.639 10.3 3 12 3Z"
-          />
-          <path fill={color} d="M13 15v5.5l1 1.5h-4l1-1.5V15z" />
-        </svg>
-      );
-    }),
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        height={height}
+        width={width}
+        role="img"
+        ref={ref}
+        aria-labelledby={titleId}
+        {...props}
+      >
+        {title ? <title id={titleId}>{title}</title> : null}
+        <path fill="#fff" d="M0 0h24v24H0z" />
+        <path
+          stroke={color}
+          strokeWidth={2}
+          d="M12 3c1.7 0 3.483.638 4.83 1.704C18.17 5.768 19 7.187 19 8.74c0 1.554-.83 2.978-2.173 4.047C15.48 13.858 13.698 14.5 12 14.5c-1.7 0-3.482-.64-4.828-1.708C5.829 11.726 5 10.304 5 8.75s.829-2.976 2.172-4.042C8.518 3.639 10.3 3 12 3Z"
+        />
+        <path fill={color} d="M13 15v5.5l1 1.5h-4l1-1.5V15z" />
+      </svg>
+    );
+  }),
 );
 
 export default Paddle;

--- a/src/assets/formatted/Settings.tsx
+++ b/src/assets/formatted/Settings.tsx
@@ -10,50 +10,48 @@ interface SettingsProps extends React.HTMLAttributes<SVGSVGElement> {
 }
 
 const Settings = memo(
-  forwardRef < SVGSVGElement,
-  SettingsProps >
-    ((inlineProps, ref) => {
-      const { color, height, width, title, titleId: propsTitleId } = inlineProps;
-      const titleId = propsTitleId || kebabCase(title || '');
-      const hasAccessibleName = Boolean(title || inlineProps['aria-label']);
-      const props = hasAccessibleName
-        ? inlineProps
-        : {
-            ...inlineProps,
-            'aria-hidden': true,
-            role: 'presentation',
-          };
+  forwardRef<SVGSVGElement, SettingsProps>((inlineProps, ref) => {
+    const { color, height, width, title, titleId: propsTitleId } = inlineProps;
+    const titleId = propsTitleId || kebabCase(title || '');
+    const hasAccessibleName = Boolean(title || inlineProps['aria-label']);
+    const props = hasAccessibleName
+      ? inlineProps
+      : {
+          ...inlineProps,
+          'aria-hidden': true,
+          role: 'presentation',
+        };
 
-      return (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          height={height}
-          width={width}
-          role="img"
-          ref={ref}
-          aria-labelledby={titleId}
-          {...props}
-        >
-          {title ? <title id={titleId}>{title}</title> : null}
-          <path
-            stroke={color}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M18.589 14.563a1.5 1.5 0 0 0 .3 1.655l.054.054a1.818 1.818 0 1 1-2.573 2.573l-.054-.054a1.5 1.5 0 0 0-1.655-.3 1.5 1.5 0 0 0-.909 1.372v.155a1.818 1.818 0 1 1-3.636 0v-.082a1.5 1.5 0 0 0-.982-1.373 1.5 1.5 0 0 0-1.655.3l-.054.055a1.819 1.819 0 1 1-2.573-2.573l.055-.054a1.5 1.5 0 0 0 .3-1.655 1.5 1.5 0 0 0-1.373-.91h-.155a1.818 1.818 0 1 1 0-3.636h.082a1.5 1.5 0 0 0 1.373-.981 1.5 1.5 0 0 0-.3-1.655L4.779 7.4a1.818 1.818 0 1 1 2.573-2.573l.055.054a1.5 1.5 0 0 0 1.654.3h.073a1.5 1.5 0 0 0 .909-1.372v-.155a1.818 1.818 0 0 1 3.636 0v.082a1.5 1.5 0 0 0 .91 1.373 1.5 1.5 0 0 0 1.654-.3l.055-.055a1.818 1.818 0 0 1 3.106 1.286 1.82 1.82 0 0 1-.534 1.287l-.054.054a1.5 1.5 0 0 0-.3 1.655v.073a1.5 1.5 0 0 0 1.373.909h.154a1.818 1.818 0 1 1 0 3.636h-.082a1.5 1.5 0 0 0-1.372.91"
-          />
-          <path
-            stroke={color}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M11.861 8.836a3 3 0 1 1 0 6 3 3 0 0 1 0-6"
-          />
-        </svg>
-      );
-    }),
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        height={height}
+        width={width}
+        role="img"
+        ref={ref}
+        aria-labelledby={titleId}
+        {...props}
+      >
+        {title ? <title id={titleId}>{title}</title> : null}
+        <path
+          stroke={color}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M18.589 14.563a1.5 1.5 0 0 0 .3 1.655l.054.054a1.818 1.818 0 1 1-2.573 2.573l-.054-.054a1.5 1.5 0 0 0-1.655-.3 1.5 1.5 0 0 0-.909 1.372v.155a1.818 1.818 0 1 1-3.636 0v-.082a1.5 1.5 0 0 0-.982-1.373 1.5 1.5 0 0 0-1.655.3l-.054.055a1.819 1.819 0 1 1-2.573-2.573l.055-.054a1.5 1.5 0 0 0 .3-1.655 1.5 1.5 0 0 0-1.373-.91h-.155a1.818 1.818 0 1 1 0-3.636h.082a1.5 1.5 0 0 0 1.373-.981 1.5 1.5 0 0 0-.3-1.655L4.779 7.4a1.818 1.818 0 1 1 2.573-2.573l.055.054a1.5 1.5 0 0 0 1.654.3h.073a1.5 1.5 0 0 0 .909-1.372v-.155a1.818 1.818 0 0 1 3.636 0v.082a1.5 1.5 0 0 0 .91 1.373 1.5 1.5 0 0 0 1.654-.3l.055-.055a1.818 1.818 0 0 1 3.106 1.286 1.82 1.82 0 0 1-.534 1.287l-.054.054a1.5 1.5 0 0 0-.3 1.655v.073a1.5 1.5 0 0 0 1.373.909h.154a1.818 1.818 0 1 1 0 3.636h-.082a1.5 1.5 0 0 0-1.372.91"
+        />
+        <path
+          stroke={color}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M11.861 8.836a3 3 0 1 1 0 6 3 3 0 0 1 0-6"
+        />
+      </svg>
+    );
+  }),
 );
 
 export default Settings;

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -20,7 +20,7 @@ const tabs = [
 
 // Default story for Tabs component
 export const Playground = (props: TabsContainerProps & TabContentProps) => (
-  <TabsContainer {...props} defaultValue="overview">
+  <TabsContainer {...props} defaultValue="overview" tabListLabel="Sale Page Tabs">
     <TabsContent value="overview">
       <p>This content is for the Overview tab.</p>
     </TabsContent>
@@ -38,7 +38,7 @@ Playground.argTypes = {};
 
 // Story with the Browse tab selected
 export const BrowseTabSelected = () => (
-  <TabsContainer tabs={tabs} defaultValue="browse">
+  <TabsContainer tabs={tabs} defaultValue="browse" tabListLabel="Sale Page Tabs">
     <TabsContent value="overview">
       <p>This content is for the Overview tab.</p>
     </TabsContent>
@@ -54,7 +54,7 @@ export const ControlledTabs = () => {
 
   return (
     <>
-      <TabsContainer tabs={tabs} value={value} onTabClick={setValue}>
+      <TabsContainer tabs={tabs} value={value} onTabClick={setValue} tabListLabel="Sale Page Tabs">
         <TabsContent value="overview">
           <p>This content is for the Overview tab.</p>
         </TabsContent>
@@ -76,13 +76,13 @@ const componentTabs = [
   },
   {
     label: <div style={{ display: 'flex' }}>Submit {<Text style={{ color: 'blue', marginBottom: '0' }}>+</Text>}</div>,
-    value: 'Browse',
+    value: 'browse',
   },
 ];
 
 // Story with the Browse tab selected
 export const ComponentLabels = () => (
-  <TabsContainer tabs={componentTabs}>
+  <TabsContainer tabs={componentTabs} tabListLabel="Sale Page Tabs">
     <TabsContent value="overview">
       <p>This content is for the Overview tab.</p>
     </TabsContent>

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -11,13 +11,13 @@ describe('Tabs', () => {
   ];
 
   it('renders tabs', () => {
-    const { getAllByRole } = render(<TabsContainer tabs={tabs} />);
+    const { getAllByRole } = render(<TabsContainer tabs={tabs} tabListLabel="" />);
     const tabsList = getAllByRole('tablist');
     expect(tabsList.length).toBe(1);
   });
   test('renders the tabs and displays default content', () => {
     render(
-      <TabsContainer tabs={tabs} defaultValue="overview">
+      <TabsContainer tabs={tabs} defaultValue="overview" tabListLabel="Sale Page Tabs">
         <TabsContent value="overview">Overview content</TabsContent>
         <TabsContent value="browse">Browse lots content</TabsContent>
       </TabsContainer>,
@@ -46,7 +46,7 @@ describe('Tabs', () => {
       },
     ];
     render(
-      <TabsContainer tabs={componentTabs}>
+      <TabsContainer tabs={componentTabs} tabListLabel="Sale Page Tabs">
         <TabsContent value="overview">Overview content</TabsContent>
         <TabsContent value="browse">Browse lots content</TabsContent>
       </TabsContainer>,
@@ -58,7 +58,7 @@ describe('Tabs', () => {
   });
   test('displays correct content when a different tab is selected', async () => {
     render(
-      <TabsContainer tabs={tabs} defaultValue="overview">
+      <TabsContainer tabs={tabs} defaultValue="overview" tabListLabel="Sale Page Tabs">
         <TabsContent value="overview">Overview content</TabsContent>
         <TabsContent value="browse">Browse lots content</TabsContent>
       </TabsContainer>,
@@ -75,7 +75,7 @@ describe('Tabs', () => {
     const onTabClickMock = vitest.fn();
 
     render(
-      <TabsContainer tabs={tabs} defaultValue="browse" onTabClick={onTabClickMock}>
+      <TabsContainer tabs={tabs} defaultValue="browse" onTabClick={onTabClickMock} tabListLabel="Sale Page Tabs">
         <TabsContent value="overview">Overview content</TabsContent>
         <TabsContent value="browse">Browse lots content</TabsContent>
       </TabsContainer>,
@@ -88,7 +88,13 @@ describe('Tabs', () => {
     const onTabClickMock = vitest.fn();
 
     render(
-      <TabsContainer tabs={tabs} defaultValue="browse" value="browse" onTabClick={onTabClickMock}>
+      <TabsContainer
+        tabs={tabs}
+        defaultValue="browse"
+        value="browse"
+        onTabClick={onTabClickMock}
+        tabListLabel="Sale Page Tabs"
+      >
         <TabsContent value="overview">Overview content</TabsContent>
         <TabsContent value="browse">Browse lots content</TabsContent>
       </TabsContainer>,

--- a/src/components/Tabs/TabsContainer.tsx
+++ b/src/components/Tabs/TabsContainer.tsx
@@ -32,7 +32,7 @@ export interface TabsContainerProps extends TabsPrimitive.TabsProps, Omit<Compon
   /**
    * Aria-label for specific tab list view
    */
-  tabListLabel?: string;
+  tabListLabel: string;
   /**
    * Optional value for controlled tabs
    */
@@ -58,10 +58,7 @@ export interface TabsContainerProps extends TabsPrimitive.TabsProps, Omit<Compon
  */
 
 const TabsContainer = forwardRef<HTMLDivElement, TabsContainerProps>(
-  (
-    { className, tabs = [], tabListLabel = 'Sale Page Tabs', children, defaultValue, value, onTabClick, ...props },
-    ref,
-  ) => {
+  ({ className, tabs = [], tabListLabel, children, defaultValue, value, onTabClick, ...props }, ref) => {
     const { className: baseClassName, ...commonProps } = getCommonProps(props, 'TabsContainer');
     return (
       <TabsPrimitive.Root

--- a/src/patterns/SaleHeaderBanner/SaleHeaderBanner.tsx
+++ b/src/patterns/SaleHeaderBanner/SaleHeaderBanner.tsx
@@ -159,7 +159,9 @@ const SaleHeaderBanner = forwardRef<HTMLDivElement, SaleHeaderBannerProps>(
           <div className={`${baseClassName}__stack`}>
             {isOpenForBidding && auctionEndTime && showTimer ? (
               <SSRMediaQuery.Media greaterThanOrEqual="md">
-                <div className={`${baseClassName}__stack__countdown`}>{<Countdown {...countdownProps} centerAlign={true} />}</div>
+                <div className={`${baseClassName}__stack__countdown`}>
+                  {<Countdown {...countdownProps} centerAlign={true} />}
+                </div>
               </SSRMediaQuery.Media>
             ) : null}
             <Text variant={TextVariants.labelMedium} className={`${baseClassName}__header-label`}>


### PR DESCRIPTION
…e to be supplied

**Jira ticket**

[L3-12633](https://phillipsauctions.atlassian.net/browse/L3-12633)

**Summary**

TabsContainer was previously defaulting the aria label to "Sale page tabs", which was almost always wrong. This change removes the default and requires the consumer to provide one. A [separate Remix PR](https://github.com/PhillipsAuctionHouse/phillips-public-remix/pull/2160) adapts to that change.

PR incidentally includes some autoformatting, which might as well go somewhere

**Change List (describe the changes made to the files)**

This pull request primarily introduces improvements to the accessibility and consistency of the `TabsContainer` component by making the `tabListLabel` prop required and updating its usage throughout stories and tests. It also includes minor code style fixes in SVG icon components and a small formatting change in the `SaleHeaderBanner` pattern.

**Tabs accessibility and API consistency:**

* Made the `tabListLabel` prop required in the `TabsContainerProps` interface and updated the component implementation to remove the default value, ensuring that all usages explicitly provide an accessible label for the tab list. (`src/components/Tabs/TabsContainer.tsx`) [[1]](diffhunk://#diff-712ba55312c3c511b05b41acf87258ba1ee36b3c6225876511bd32257e55e51aL35-R35) [[2]](diffhunk://#diff-712ba55312c3c511b05b41acf87258ba1ee36b3c6225876511bd32257e55e51aL61-R61)
* Updated all usages of `TabsContainer` in stories and tests to provide the `tabListLabel` prop, standardizing on "Sale Page Tabs" as the label. (`src/components/Tabs/Tabs.stories.tsx`, `src/components/Tabs/Tabs.test.tsx`) [[1]](diffhunk://#diff-2a452b882d4815ca174cd096d1132b0356c6e9579865ae431f96c00b4088e209L23-R23) [[2]](diffhunk://#diff-2a452b882d4815ca174cd096d1132b0356c6e9579865ae431f96c00b4088e209L41-R41) [[3]](diffhunk://#diff-2a452b882d4815ca174cd096d1132b0356c6e9579865ae431f96c00b4088e209L57-R57) [[4]](diffhunk://#diff-2a452b882d4815ca174cd096d1132b0356c6e9579865ae431f96c00b4088e209L79-R85) [[5]](diffhunk://#diff-abd2eeb3fac728033c05447537729dc4f7a30bd0077523656773d7408e39df17L14-R20) [[6]](diffhunk://#diff-abd2eeb3fac728033c05447537729dc4f7a30bd0077523656773d7408e39df17L49-R49) [[7]](diffhunk://#diff-abd2eeb3fac728033c05447537729dc4f7a30bd0077523656773d7408e39df17L61-R61) [[8]](diffhunk://#diff-abd2eeb3fac728033c05447537729dc4f7a30bd0077523656773d7408e39df17L78-R78) [[9]](diffhunk://#diff-abd2eeb3fac728033c05447537729dc4f7a30bd0077523656773d7408e39df17L91-R97)

**Bug fixes and code quality:**

* Fixed a typo in the `componentTabs` array where the tab value was incorrectly capitalized (`'Browse'` → `'browse'`). (`src/components/Tabs/Tabs.stories.tsx`)
* Reformatted the countdown timer container in `SaleHeaderBanner` for improved readability. (`src/patterns/SaleHeaderBanner/SaleHeaderBanner.tsx`)

**Code style improvements:**

* Fixed spacing in the `forwardRef` usage for the `Paddle` and `Settings` SVG components for consistency with standard React patterns. (`src/assets/formatted/Paddle.tsx`, `src/assets/formatted/Settings.tsx`) [[1]](diffhunk://#diff-09d7157945f5026001cde532b8d4df5a833d4f5d2f4e7a08b2d48eb9edc4cb66L13-R13) [[2]](diffhunk://#diff-5d51e4ac9089cc4f4a45cd17aa120787cf09ee7d8c0a21b0d417f39bc55174b6L13-R13)




<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.


[L3-12633]: https://phillipsauctions.atlassian.net/browse/L3-12633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ