### PR TITLE
fix(accordion): L3-0000 align expand/collapse animation with Radix pattern

### DIFF
--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -16,26 +16,16 @@
     border-bottom: 1px solid $light-gray;
   }
 
-  &[data-state='open'] {
-    display: block;
-    height: auto;
-    padding-bottom: $spacing-sm;
-  }
-
   &__content {
-    margin-bottom: $spacing-sm;
+    display: block;
+
+    .radix-accordion-content {
+      padding-bottom: $spacing-sm;
+    }
 
     &--locked {
       padding-bottom: $spacing-sm;
     }
-  }
-
-  &--transition[data-state='open'] {
-    animation: slide-down var(--seldon-accordion-transition-time) ease-in-out;
-  }
-
-  &--transition[data-state='closed'] {
-    animation: slide-up var(--seldon-accordion-transition-time) ease-in-out;
   }
 
   &--transition {
@@ -43,11 +33,11 @@
   }
 
   &--transition[data-state='open'] {
-    animation: slide-down var(--seldon-accordion-transition-time) ease-in-out;
+    animation: slide-down var(--seldon-accordion-transition-time) ease-out;
   }
 
   &--transition[data-state='closed'] {
-    animation: slide-up var(--seldon-accordion-transition-time) ease-in-out;
+    animation: slide-up var(--seldon-accordion-transition-time) ease-out forwards;
   }
 
   &[data-state='open'] {
@@ -73,25 +63,20 @@
   @keyframes slide-down {
     from {
       height: 0;
-      opacity: 0;
     }
 
     to {
       height: var(--radix-accordion-content-height);
-      opacity: 1;
     }
   }
 
   @keyframes slide-up {
     from {
       height: var(--radix-accordion-content-height);
-      opacity: 1;
     }
 
     to {
       height: 0;
-      opacity: 0;
-      padding: 0;
     }
   }
 }


### PR DESCRIPTION
**Jira ticket**

[L3-13058](https://phillipsauctions.atlassian.net/browse/L3-13058)

**Screenshots**


https://github.com/user-attachments/assets/9036de28-61d6-4018-8c64-94fc630a7bb2



_Video of before/after animation to be added._

**Summary**

The accordion expand/collapse animation didn't follow the [Radix accordion animation pattern](https://www.radix-ui.com/primitives/docs/components/accordion#animating-content-size), which caused two visible glitches:

- The close animation stopped short and the bottom spacing disappeared in a one-frame jump. Root cause: `padding-bottom` lived on the animated `Accordion.Content` element itself, so the keyframed `height` could never reach a true `0`. Radix docs require padding to live on a child of `Content`.
- The content didn't visibly slide at all in some cases. Root cause: `Accordion.Content` renders (via `asChild` + `Text`) as an inline `<span>`, which ignores `height` animation and vertical padding.

**Change List**

- Moved bottom spacing from the Item's `[data-state='open']` padding / Content's dead `margin-bottom` (vertical margins don't apply to inline elements) to `padding-bottom` on the inner `.radix-accordion-content` wrapper
- Added `display: block` to `__content` so the `<span>` rendered by `Text` honors height animation and padding
- Keyframes now animate `height` only (removed `opacity` and a broken `padding: 0`), matching the Radix reference
- `ease-in-out` → `ease-out`, matching the Radix reference
- Added `animation-fill-mode: forwards` to `slide-up` only, so the closed content holds at height 0 until Radix unmounts it (no end-frame flash); open content is not pinned so it can reflow after opening
- Removed duplicated `--transition[data-state]` rule blocks

**Acceptance Test (how to verify the PR)**

1. Run Storybook and open `Components/Accordion` → `Default`
2. Expand "Provenance" or "Exhibited" (both have `hasTransition: true`) — content should slide down smoothly from the very start (no initial pop)
3. Collapse it — content should slide up the full distance with no jump when the bottom padding disappears
4. Confirm bottom spacing below open content is unchanged (`$spacing-sm`)

**Regression Test**

- Items without `hasTransition` (e.g. via `AccordionSubmenu` story) still open/close instantly with identical spacing
- Locked items ("Condition Report") still show the lock icon and keep their content spacing
- Plus/minus icon toggle on open/close unchanged

**Evidence of testing**

- All 20 Accordion unit tests pass (`vitest run src/components/Accordion/`)
- stylelint clean
- Verified manually in Storybook

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

[L3-13058]: https://phillipsauctions.atlassian.net/browse/L3-13058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ