### PR TITLE
feat(TextBanner): PDD-278 update content-wrapper vertical padding

### DIFF
--- a/src/patterns/TextBanner/_textBanner.scss
+++ b/src/patterns/TextBanner/_textBanner.scss
@@ -14,7 +14,7 @@
     flex-direction: column;
     justify-content: space-between;
     max-width: none;
-    padding: $spacing-lg 0;
+    padding: 24px 0;
 
     h1 {
       white-space: nowrap;
@@ -33,6 +33,7 @@
 
     @include media($breakpoint-md) {
       flex-direction: row;
+      padding-block: 32px;
 
       h1,
       p,

--- a/src/patterns/TextBanner/_textBanner.scss
+++ b/src/patterns/TextBanner/_textBanner.scss
@@ -14,7 +14,7 @@
     flex-direction: column;
     justify-content: space-between;
     max-width: none;
-    padding: 24px 0;
+    padding: $spacing-lg 0;
 
     h1 {
       white-space: nowrap;
@@ -33,7 +33,7 @@
 
     @include media($breakpoint-md) {
       flex-direction: row;
-      padding-block: 32px;
+      padding-block: $spacing-xl;
 
       h1,
       p,

--- a/src/patterns/TextBanner/_textBanner.scss
+++ b/src/patterns/TextBanner/_textBanner.scss
@@ -14,7 +14,7 @@
     flex-direction: column;
     justify-content: space-between;
     max-width: none;
-    padding: $spacing-lg 0;
+    padding: 24px 0;
 
     h1 {
       white-space: nowrap;
@@ -33,7 +33,7 @@
 
     @include media($breakpoint-md) {
       flex-direction: row;
-      padding-block: $spacing-xl;
+      padding-block: 32px;
 
       h1,
       p,

--- a/src/patterns/TextBanner/_textBanner.scss
+++ b/src/patterns/TextBanner/_textBanner.scss
@@ -14,8 +14,7 @@
     flex-direction: column;
     justify-content: space-between;
     max-width: none;
-    // No legacy spacing token maps to the requested 24px vertical padding.
-    padding: 24px 0;
+    padding: $spacing-lg 0;
 
     h1 {
       white-space: nowrap;
@@ -34,8 +33,7 @@
 
     @include media($breakpoint-md) {
       flex-direction: row;
-      // No legacy spacing token maps to the requested 32px vertical padding.
-      padding-block: 32px;
+      padding-block: $spacing-xl;
 
       h1,
       p,

--- a/src/patterns/TextBanner/_textBanner.scss
+++ b/src/patterns/TextBanner/_textBanner.scss
@@ -14,7 +14,8 @@
     flex-direction: column;
     justify-content: space-between;
     max-width: none;
-    padding: $spacing-lg 0;
+    // No legacy spacing token maps to the requested 24px vertical padding.
+    padding: 24px 0;
 
     h1 {
       white-space: nowrap;
@@ -33,7 +34,8 @@
 
     @include media($breakpoint-md) {
       flex-direction: row;
-      padding-block: $spacing-xl;
+      // No legacy spacing token maps to the requested 32px vertical padding.
+      padding-block: 32px;
 
       h1,
       p,


### PR DESCRIPTION
Set `TextBanner` content-wrapper vertical padding to **24px** on mobile/tablet and **32px** on desktop (≥961px), per updated design. Horizontal padding unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)