### PR TITLE
feat(FiltersInline): PDD-289 update editorial hub filters

### DIFF
--- a/src/patterns/FiltersInline/FilterButton.tsx
+++ b/src/patterns/FiltersInline/FilterButton.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import React from 'react';
 import Button from '../../components/Button/Button';
-import { ButtonVariants } from '../../components/Button/types';
+import { ButtonSizes, ButtonVariants } from '../../components/Button/types';
 import { Icon } from '../../components/Icon';
 import { Text, TextVariants } from '../../components/Text';
 import { px } from '../../utils';
@@ -47,6 +47,7 @@ export const FilterButton = React.forwardRef<HTMLButtonElement, FilterButton>(
       })}
       aria-label={ariaLabel}
       variant={ButtonVariants.secondary}
+      size={ButtonSizes.small}
       data-testid={`${id}-filter-button`}
       data-viewport={isMobile ? 'mobile' : 'desktop'}
       onClick={onClick}

--- a/src/patterns/FiltersInline/FilterDropdownMenuDesktop.tsx
+++ b/src/patterns/FiltersInline/FilterDropdownMenuDesktop.tsx
@@ -5,7 +5,7 @@ import { ButtonSizes, ButtonVariants } from '../../components/Button/types';
 import FilterInput from '../../components/Filter/FilterInput';
 import { px } from '../../utils';
 import { FilterDimension, FilterDropdownMenuProps } from './types';
-import { getFilterDimensions, handleInputChange as handleInputChangeUtil } from './utils';
+import { getFilterDimensions, handleInputChange as handleInputChangeUtil, hasActiveDimensions } from './utils';
 
 export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, FilterDropdownMenuProps>(
   (
@@ -26,7 +26,7 @@ export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, Filter
     const isSortButton = buttonType === 'Sort';
     const baseClassName = `${px}-filter-dropdown-menu`;
     const filterDimensions = getFilterDimensions(filters, filterIndex);
-    const hasActiveFilters = filterDimensions.some((dimension) => dimension.active);
+    const hasActiveFilters = hasActiveDimensions(filters, buttonType, filterIndex);
 
     return (
       <div

--- a/src/patterns/FiltersInline/FilterDropdownMenuDesktop.tsx
+++ b/src/patterns/FiltersInline/FilterDropdownMenuDesktop.tsx
@@ -25,7 +25,8 @@ export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, Filter
   ) => {
     const isSortButton = buttonType === 'Sort';
     const baseClassName = `${px}-filter-dropdown-menu`;
-    const hasActiveFilters = getFilterDimensions(filters, filterIndex).some((dimension) => dimension.active);
+    const filterDimensions = getFilterDimensions(filters, filterIndex);
+    const hasActiveFilters = filterDimensions.some((dimension) => dimension.active);
 
     return (
       <div
@@ -35,7 +36,7 @@ export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, Filter
         aria-label={ariaLabels || `${buttonType} dropdown desktop`}
       >
         <div className={classnames(`${baseClassName}__filters`)}>
-          {getFilterDimensions(filters, filterIndex).map((value: FilterDimension) => (
+          {filterDimensions.map((value: FilterDimension) => (
             <FilterInput
               id={value.label}
               key={value.label}
@@ -61,7 +62,6 @@ export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, Filter
           ) : (
             <>
               <Button
-                className={classnames(`${baseClassName}__buttons`)}
                 variant={ButtonVariants.secondary}
                 size={ButtonSizes.small}
                 isDisabled={!hasActiveFilters}
@@ -69,12 +69,7 @@ export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, Filter
               >
                 {dropdownMenuTranslation?.clearAll || 'Clear all'}
               </Button>
-              <Button
-                className={classnames(`${baseClassName}__buttons`)}
-                variant={ButtonVariants.primary}
-                size={ButtonSizes.small}
-                onClick={() => onApplyFilter?.(false)}
-              >
+              <Button variant={ButtonVariants.primary} size={ButtonSizes.small} onClick={() => onApplyFilter?.(false)}>
                 <span className={`${baseClassName}__button-text`}>
                   {dropdownMenuTranslation?.showAuctions || `Show ${resultsCount} Auctions`}
                 </span>

--- a/src/patterns/FiltersInline/FilterDropdownMenuDesktop.tsx
+++ b/src/patterns/FiltersInline/FilterDropdownMenuDesktop.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import React from 'react';
 import Button from '../../components/Button/Button';
-import { ButtonVariants } from '../../components/Button/types';
+import { ButtonSizes, ButtonVariants } from '../../components/Button/types';
 import FilterInput from '../../components/Filter/FilterInput';
 import { px } from '../../utils';
 import { FilterDimension, FilterDropdownMenuProps } from './types';
@@ -25,6 +25,7 @@ export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, Filter
   ) => {
     const isSortButton = buttonType === 'Sort';
     const baseClassName = `${px}-filter-dropdown-menu`;
+    const hasActiveFilters = getFilterDimensions(filters, filterIndex).some((dimension) => dimension.active);
 
     return (
       <div
@@ -52,6 +53,7 @@ export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, Filter
             <Button
               className={classnames(`${baseClassName}__button`)}
               variant={ButtonVariants.primary}
+              size={ButtonSizes.small}
               onClick={() => onApplyFilter?.(false)}
             >
               <span className={`${baseClassName}__button-text`}>{dropdownMenuTranslation?.confirm || 'Confirm'}</span>
@@ -61,6 +63,8 @@ export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, Filter
               <Button
                 className={classnames(`${baseClassName}__buttons`)}
                 variant={ButtonVariants.secondary}
+                size={ButtonSizes.small}
+                isDisabled={!hasActiveFilters}
                 onClick={() => onClickClear?.(buttonType ?? '')}
               >
                 {dropdownMenuTranslation?.clearAll || 'Clear all'}
@@ -68,6 +72,7 @@ export const FilterDropdownMenuDesktop = React.forwardRef<HTMLDivElement, Filter
               <Button
                 className={classnames(`${baseClassName}__buttons`)}
                 variant={ButtonVariants.primary}
+                size={ButtonSizes.small}
                 onClick={() => onApplyFilter?.(false)}
               >
                 <span className={`${baseClassName}__button-text`}>

--- a/src/patterns/FiltersInline/FilterDropdownMenuMobile.tsx
+++ b/src/patterns/FiltersInline/FilterDropdownMenuMobile.tsx
@@ -7,7 +7,7 @@ import Text from '../../components/Text/Text';
 import { TextVariants } from '../../components/Text/types';
 import { px } from '../../utils';
 import { FilterDimension, FilterDropdownMenuProps } from './types';
-import { getFilterDimensions, handleInputChange as handleInputChangeUtil } from './utils';
+import { getFilterDimensions, handleInputChange as handleInputChangeUtil, hasActiveDimensions } from './utils';
 
 export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterDropdownMenuProps>(
   (
@@ -28,7 +28,7 @@ export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterD
     const isSortButton = buttonType === 'Sort';
     const baseClassName = `${px}-filter-dropdown-menu`;
     const filterDimensions = getFilterDimensions(filters, filterIndex);
-    const hasActiveFilters = filterDimensions.some((dimension) => dimension.active);
+    const hasActiveFilters = hasActiveDimensions(filters, buttonType, filterIndex);
 
     return (
       <div

--- a/src/patterns/FiltersInline/FilterDropdownMenuMobile.tsx
+++ b/src/patterns/FiltersInline/FilterDropdownMenuMobile.tsx
@@ -27,7 +27,8 @@ export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterD
   ) => {
     const isSortButton = buttonType === 'Sort';
     const baseClassName = `${px}-filter-dropdown-menu`;
-    const hasActiveFilters = getFilterDimensions(filters, filterIndex).some((dimension) => dimension.active);
+    const filterDimensions = getFilterDimensions(filters, filterIndex);
+    const hasActiveFilters = filterDimensions.some((dimension) => dimension.active);
 
     return (
       <div
@@ -37,7 +38,7 @@ export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterD
         aria-label={ariaLabels || `${buttonType} dropdown mobile`}
       >
         <div className={classnames(`${baseClassName}__filters`, `${baseClassName}__filters--mobile`)}>
-          {getFilterDimensions(filters, filterIndex).map((value: FilterDimension) => (
+          {filterDimensions.map((value: FilterDimension) => (
             <FilterInput
               id={value.label}
               key={value.label}
@@ -70,11 +71,6 @@ export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterD
           ) : (
             <>
               <Button
-                className={classnames(
-                  `${baseClassName}__buttons`,
-                  `${baseClassName}__buttons--mobile`,
-                  `${baseClassName}__buttons--left`,
-                )}
                 variant={ButtonVariants.secondary}
                 size={ButtonSizes.small}
                 isDisabled={!hasActiveFilters}
@@ -82,16 +78,7 @@ export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterD
               >
                 <Text variant={TextVariants.bodySmall}>{dropdownMenuTranslation?.clearAll || 'Clear all'}</Text>
               </Button>
-              <Button
-                className={classnames(
-                  `${baseClassName}__buttons`,
-                  `${baseClassName}__buttons--mobile`,
-                  `${baseClassName}__buttons--right`,
-                )}
-                variant={ButtonVariants.primary}
-                size={ButtonSizes.small}
-                onClick={() => onApplyFilter?.(false)}
-              >
+              <Button variant={ButtonVariants.primary} size={ButtonSizes.small} onClick={() => onApplyFilter?.(false)}>
                 <Text variant={TextVariants.bodySmall} className={`${baseClassName}__button-text`}>
                   {dropdownMenuTranslation?.showAuctions || `Show ${resultsCount} Auctions`}
                 </Text>

--- a/src/patterns/FiltersInline/FilterDropdownMenuMobile.tsx
+++ b/src/patterns/FiltersInline/FilterDropdownMenuMobile.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import React from 'react';
 import Button from '../../components/Button/Button';
-import { ButtonVariants } from '../../components/Button/types';
+import { ButtonSizes, ButtonVariants } from '../../components/Button/types';
 import FilterInput from '../../components/Filter/FilterInput';
 import Text from '../../components/Text/Text';
 import { TextVariants } from '../../components/Text/types';
@@ -27,6 +27,7 @@ export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterD
   ) => {
     const isSortButton = buttonType === 'Sort';
     const baseClassName = `${px}-filter-dropdown-menu`;
+    const hasActiveFilters = getFilterDimensions(filters, filterIndex).some((dimension) => dimension.active);
 
     return (
       <div
@@ -59,6 +60,7 @@ export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterD
             <Button
               className={classnames(`${baseClassName}__button`, `${baseClassName}__button--mobile`)}
               variant={ButtonVariants.primary}
+              size={ButtonSizes.small}
               onClick={() => onApplyFilter?.(false)}
             >
               <Text variant={TextVariants.headingMedium} className={`${baseClassName}__button-text`}>
@@ -74,6 +76,8 @@ export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterD
                   `${baseClassName}__buttons--left`,
                 )}
                 variant={ButtonVariants.secondary}
+                size={ButtonSizes.small}
+                isDisabled={!hasActiveFilters}
                 onClick={() => onClickClear?.(buttonType ?? '')}
               >
                 <Text variant={TextVariants.bodySmall}>{dropdownMenuTranslation?.clearAll || 'Clear all'}</Text>
@@ -85,6 +89,7 @@ export const FilterDropdownMenuMobile = React.forwardRef<HTMLDivElement, FilterD
                   `${baseClassName}__buttons--right`,
                 )}
                 variant={ButtonVariants.primary}
+                size={ButtonSizes.small}
                 onClick={() => onApplyFilter?.(false)}
               >
                 <Text variant={TextVariants.bodySmall} className={`${baseClassName}__button-text`}>

--- a/src/patterns/FiltersInline/FiltersInline.test.tsx
+++ b/src/patterns/FiltersInline/FiltersInline.test.tsx
@@ -187,7 +187,7 @@ describe('MainFilterDropdown', () => {
     expect(screen.getByTestId('main-filter-filter-button')).toHaveAttribute('aria-label', 'Filter Button');
   });
 
-  it('calls clearFilterUpdate with "all" when Clear All button is clicked', () => {
+  it('disables Clear All when no filters are selected', () => {
     render(
       <MainFilterDropdown
         id="main-filter"
@@ -197,6 +197,37 @@ describe('MainFilterDropdown', () => {
         handleClick={handleClick}
         filtersListState={[true]}
         filters={filters}
+        onSelectFilter={handleFilterSelection}
+        onApplyFilter={handleFilterUpdate}
+        onClickClear={clearFilterUpdate}
+        resultsCount={2}
+        ariaLabels={{ button: 'Filter Button' }}
+      />,
+    );
+    expect(screen.getByText(/Clear All/i)).toBeDisabled();
+    fireEvent.click(screen.getByText(/Clear All/i));
+    expect(clearFilterUpdate).not.toHaveBeenCalled();
+  });
+
+  it('calls clearFilterUpdate with "all" when Clear All button is clicked', () => {
+    const activeFilters = [
+      {
+        ...filters[0],
+        filterDimensions: new Set([
+          { label: 'Foo', active: true, disabled: false },
+          { label: 'Bar', active: false, disabled: false },
+        ]),
+      },
+    ];
+    render(
+      <MainFilterDropdown
+        id="main-filter"
+        filterButtonLabel="Filter"
+        filterId={0}
+        buttonType={'Filter' as FilterButtonType}
+        handleClick={handleClick}
+        filtersListState={[true]}
+        filters={activeFilters}
         onSelectFilter={handleFilterSelection}
         onApplyFilter={handleFilterUpdate}
         onClickClear={clearFilterUpdate}
@@ -273,27 +304,28 @@ describe('SubFilterDropdown', () => {
 });
 
 describe('FilterDropdownMenuDesktop non-sort buttons', () => {
+  const makeFilters = (fooActive: boolean) => [
+    {
+      label: 'Departments',
+      id: 'Departments',
+      type: 'checkbox' as const,
+      buttonType: FilterButtonType.Departments,
+      filterDimensions: new Set([
+        { label: 'Foo', active: fooActive, disabled: false },
+        { label: 'Bar', active: false, disabled: false },
+      ]),
+    },
+  ];
+
   it('renders and handles Clear all and Show Auctions buttons', () => {
     const handleFilterUpdate = vi.fn();
     const clearFilterUpdate = vi.fn();
-    const filters = [
-      {
-        label: 'Departments',
-        id: 'Departments',
-        type: 'checkbox' as const,
-        buttonType: FilterButtonType.Departments,
-        filterDimensions: new Set([
-          { label: 'Foo', active: false, disabled: false },
-          { label: 'Bar', active: false, disabled: false },
-        ]),
-      },
-    ];
 
     render(
       <FilterDropdownMenuDesktop
         buttonType="Departments"
-        filters={filters}
-        filterIndex={0}
+        filters={makeFilters(true)}
+        filterIndex={1}
         onSelectFilter={vi.fn()}
         onApplyFilter={handleFilterUpdate}
         onClickClear={clearFilterUpdate}
@@ -311,30 +343,52 @@ describe('FilterDropdownMenuDesktop non-sort buttons', () => {
     fireEvent.click(screen.getByText('Show 7 Auctions'));
     expect(handleFilterUpdate).toHaveBeenCalledWith(false);
   });
+
+  it('disables Clear all when no filters in the group are selected', () => {
+    const clearFilterUpdate = vi.fn();
+
+    render(
+      <FilterDropdownMenuDesktop
+        buttonType="Departments"
+        filters={makeFilters(false)}
+        filterIndex={1}
+        onSelectFilter={vi.fn()}
+        onApplyFilter={vi.fn()}
+        onClickClear={clearFilterUpdate}
+        resultsCount={7}
+        filterButtonLabel="Departments"
+      />,
+    );
+
+    expect(screen.getByText('Clear all')).toBeDisabled();
+    fireEvent.click(screen.getByText('Clear all'));
+    expect(clearFilterUpdate).not.toHaveBeenCalled();
+  });
 });
 
 describe('FilterDropdownMenuMobile non-sort buttons', () => {
+  const makeFilters = (fooActive: boolean) => [
+    {
+      label: 'Departments',
+      id: 'Departments',
+      type: 'checkbox' as const,
+      buttonType: FilterButtonType.Departments,
+      filterDimensions: new Set([
+        { label: 'Foo', active: fooActive, disabled: false },
+        { label: 'Bar', active: false, disabled: false },
+      ]),
+    },
+  ];
+
   it('renders and handles Clear all and Show Auctions buttons', () => {
     const handleFilterUpdate = vi.fn();
     const clearFilterUpdate = vi.fn();
-    const filters = [
-      {
-        label: 'Departments',
-        id: 'Departments',
-        type: 'checkbox',
-        buttonType: FilterButtonType.Departments,
-        filterDimensions: new Set([
-          { label: 'Foo', active: false, disabled: false },
-          { label: 'Bar', active: false, disabled: false },
-        ]),
-      },
-    ];
 
     render(
       <FilterDropdownMenuMobile
         buttonType="Departments"
-        filters={filters}
-        filterIndex={0}
+        filters={makeFilters(true)}
+        filterIndex={1}
         onSelectFilter={vi.fn()}
         onApplyFilter={handleFilterUpdate}
         onClickClear={clearFilterUpdate}
@@ -351,6 +405,27 @@ describe('FilterDropdownMenuMobile non-sort buttons', () => {
 
     fireEvent.click(screen.getByText('Show 5 Auctions'));
     expect(handleFilterUpdate).toHaveBeenCalledWith(false);
+  });
+
+  it('disables Clear all when no filters in the group are selected', () => {
+    const clearFilterUpdate = vi.fn();
+
+    render(
+      <FilterDropdownMenuMobile
+        buttonType="Departments"
+        filters={makeFilters(false)}
+        filterIndex={1}
+        onSelectFilter={vi.fn()}
+        onApplyFilter={vi.fn()}
+        onClickClear={clearFilterUpdate}
+        resultsCount={5}
+        filterButtonLabel="Departments"
+      />,
+    );
+
+    expect(screen.getByText('Clear all').closest('button')).toBeDisabled();
+    fireEvent.click(screen.getByText('Clear all'));
+    expect(clearFilterUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/src/patterns/FiltersInline/FiltersInline.test.tsx
+++ b/src/patterns/FiltersInline/FiltersInline.test.tsx
@@ -7,7 +7,7 @@ import FiltersInline from './FiltersInline';
 import { MainFilterDropdown } from './MainFilterDropdown';
 import { SubFilterDropdown } from './SubFilterDropdown';
 import { FilterButtonIconType, FilterButtonType, FilterType } from './types';
-import { getFilterButtonClickHandler, handleInputChange, resetAllFilters } from './utils';
+import { getFilterButtonClickHandler, handleInputChange, hasActiveDimensions, resetAllFilters } from './utils';
 
 describe('FiltersInline', () => {
   runCommonTests(FiltersInline, 'FiltersInline');
@@ -488,6 +488,31 @@ describe('getFilterButtonClickHandler', () => {
     const handler = getFilterButtonClickHandler(mockState, undefined, 0);
 
     handler();
+  });
+});
+
+describe('hasActiveDimensions', () => {
+  const filters: FilterType[] = [
+    {
+      label: 'Sale',
+      id: 'Sale',
+      type: 'checkbox' as const,
+      buttonType: FilterButtonType.Sale,
+      filterDimensions: new Set([{ label: 'Online Auction', active: false }]),
+    },
+    {
+      label: 'Departments',
+      id: 'Departments',
+      type: 'checkbox' as const,
+      buttonType: FilterButtonType.Departments,
+      filterDimensions: new Set([{ label: 'Design', active: true }]),
+    },
+  ];
+
+  it('checks active dimensions by filter id', () => {
+    expect(hasActiveDimensions(filters, 'Sale')).toBe(false);
+    expect(hasActiveDimensions(filters, 'Departments')).toBe(true);
+    expect(hasActiveDimensions(filters, 'Location')).toBe(false);
   });
 });
 

--- a/src/patterns/FiltersInline/FiltersInline.test.tsx
+++ b/src/patterns/FiltersInline/FiltersInline.test.tsx
@@ -301,6 +301,29 @@ describe('SubFilterDropdown', () => {
     buttons.forEach((btn) => fireEvent.click(btn));
     expect(handleClick).toHaveBeenCalled();
   });
+
+  it('closes the mobile drawer when the overlay is clicked', () => {
+    render(
+      <SubFilterDropdown
+        id="sub-filter"
+        filterButtonLabel="Sort"
+        filterId={1}
+        buttonType={'Sort' as FilterButtonType}
+        handleClick={handleClick}
+        filtersListState={[false, true]}
+        filters={filters}
+        onSelectFilter={handleFilterSelection}
+        onApplyFilter={handleFilterUpdate}
+        onClickClear={clearFilterUpdate}
+        resultsCount={2}
+        ariaLabels={{ button: 'Sort Button' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('drawer-overlay'));
+
+    expect(handleClick).toHaveBeenCalledWith([false, false]);
+  });
 });
 
 describe('FilterDropdownMenuDesktop non-sort buttons', () => {

--- a/src/patterns/FiltersInline/MainFilterDropdown.tsx
+++ b/src/patterns/FiltersInline/MainFilterDropdown.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import React from 'react';
 import Button from '../../components/Button/Button';
-import { ButtonVariants } from '../../components/Button/types';
+import { ButtonSizes, ButtonVariants } from '../../components/Button/types';
 import Drawer from '../../components/Drawer/Drawer';
 import Filter from '../../components/Filter/Filter';
 import FilterHeader from '../../components/Filter/FilterHeader';
@@ -83,11 +83,17 @@ export const MainFilterDropdown = React.forwardRef<HTMLButtonElement, FilterDrop
             <Button
               className={`${px}-filter-dropdown-menu__button`}
               variant={ButtonVariants.secondary}
+              size={ButtonSizes.small}
+              isDisabled={totalCount === 0}
               onClick={() => onClickClear?.('all')}
             >
               {dropdownMenuTranslation?.clearAll || 'Clear all'}
             </Button>
-            <Button className={`${px}-filter-dropdown-menu__button`} onClick={() => onApplyFilter?.(false)}>
+            <Button
+              className={`${px}-filter-dropdown-menu__button`}
+              size={ButtonSizes.small}
+              onClick={() => onApplyFilter?.(false)}
+            >
               {dropdownMenuTranslation?.showAuctions || `Show ${resultsCount} Auctions`}
             </Button>
           </div>

--- a/src/patterns/FiltersInline/MainFilterDropdown.tsx
+++ b/src/patterns/FiltersInline/MainFilterDropdown.tsx
@@ -81,7 +81,6 @@ export const MainFilterDropdown = React.forwardRef<HTMLButtonElement, FilterDrop
             )}
           >
             <Button
-              className={`${px}-filter-dropdown-menu__button`}
               variant={ButtonVariants.secondary}
               size={ButtonSizes.small}
               isDisabled={totalCount === 0}
@@ -89,11 +88,7 @@ export const MainFilterDropdown = React.forwardRef<HTMLButtonElement, FilterDrop
             >
               {dropdownMenuTranslation?.clearAll || 'Clear all'}
             </Button>
-            <Button
-              className={`${px}-filter-dropdown-menu__button`}
-              size={ButtonSizes.small}
-              onClick={() => onApplyFilter?.(false)}
-            >
+            <Button size={ButtonSizes.small} onClick={() => onApplyFilter?.(false)}>
               {dropdownMenuTranslation?.showAuctions || `Show ${resultsCount} Auctions`}
             </Button>
           </div>

--- a/src/patterns/FiltersInline/SubFilterDropdown.tsx
+++ b/src/patterns/FiltersInline/SubFilterDropdown.tsx
@@ -33,6 +33,9 @@ export const SubFilterDropdown = React.forwardRef<HTMLButtonElement, FilterDropd
     const isButtonSelected = filtersListState?.[filterId] ?? false;
     const { totalCount, filterCount } = countActiveFilters(filters, buttonType);
     const buttonLabel = getFilterButtonLabel(filterButtonLabel, filterButtonLabelTranslated || null);
+    const isSortFilter = buttonType === FilterButtonType.Sort;
+    // Flag the Sort filter's wrapper so FiltersInline can align it to the right of the filter row on desktop.
+    const mediaClassName = isSortFilter ? `${px}-filters-inline__sort` : undefined;
 
     if (hideDesktopSortButton && buttonType === FilterButtonType.Sort) {
       return null;
@@ -40,7 +43,7 @@ export const SubFilterDropdown = React.forwardRef<HTMLButtonElement, FilterDropd
 
     return (
       <>
-        <SSRMediaQuery.Media lessThan={Breakpoints.md}>
+        <SSRMediaQuery.Media lessThan={Breakpoints.md} className={mediaClassName}>
           <FilterButton
             ref={ref}
             className={className}
@@ -78,7 +81,7 @@ export const SubFilterDropdown = React.forwardRef<HTMLButtonElement, FilterDropd
             />
           </Drawer>
         </SSRMediaQuery.Media>
-        <SSRMediaQuery.Media greaterThanOrEqual={Breakpoints.md}>
+        <SSRMediaQuery.Media greaterThanOrEqual={Breakpoints.md} className={mediaClassName}>
           <Popover.Root
             key={`${id}-${filterButtonLabel}-button`}
             open={isButtonSelected}

--- a/src/patterns/FiltersInline/SubFilterDropdown.tsx
+++ b/src/patterns/FiltersInline/SubFilterDropdown.tsx
@@ -34,7 +34,6 @@ export const SubFilterDropdown = React.forwardRef<HTMLButtonElement, FilterDropd
     const { totalCount, filterCount } = countActiveFilters(filters, buttonType);
     const buttonLabel = getFilterButtonLabel(filterButtonLabel, filterButtonLabelTranslated || null);
     const isSortFilter = buttonType === FilterButtonType.Sort;
-    // Flag the Sort filter's wrapper so FiltersInline can align it to the right of the filter row on desktop.
     const mediaClassName = isSortFilter ? `${px}-filters-inline__sort` : undefined;
 
     if (hideDesktopSortButton && buttonType === FilterButtonType.Sort) {

--- a/src/patterns/FiltersInline/SubFilterDropdown.tsx
+++ b/src/patterns/FiltersInline/SubFilterDropdown.tsx
@@ -7,7 +7,7 @@ import { FilterButton } from './FilterButton';
 import { FilterDropdownMenuDesktop } from './FilterDropdownMenuDesktop';
 import { FilterDropdownMenuMobile } from './FilterDropdownMenuMobile';
 import { FilterButtonType, type FilterButtonIconType, type FilterDropdownProps } from './types';
-import { countActiveFilters, getFilterButtonClickHandler, getFilterButtonLabel } from './utils';
+import { countActiveFilters, getFilterButtonClickHandler, getFilterButtonLabel, resetAllFilters } from './utils';
 export const SubFilterDropdown = React.forwardRef<HTMLButtonElement, FilterDropdownProps>(
   (
     {
@@ -59,7 +59,7 @@ export const SubFilterDropdown = React.forwardRef<HTMLButtonElement, FilterDropd
           <Drawer
             drawerOpenSide="bottom"
             isOpen={isButtonSelected}
-            onClose={getFilterButtonClickHandler(filtersListState, handleClick, filterId)}
+            onClose={() => resetAllFilters(filtersListState, handleClick)}
             aria-label={ariaLabels.drawer || `${filterButtonLabel} drawer`}
             className={`${px}-filter-drawer-mobile`}
             headerText={buttonLabel}

--- a/src/patterns/FiltersInline/_filterDropdownMenu.scss
+++ b/src/patterns/FiltersInline/_filterDropdownMenu.scss
@@ -1,9 +1,6 @@
 @use '~scss/allPartials' as *;
 
 $dropdown-height: 240px;
-
-// Fixed width wide enough for the two footer CTAs (Clear all / Show N) to sit side-by-side on one
-// line, and for long option labels (e.g. "Modern & Contemporary Art") not to wrap.
 $dropdown-width: 320px;
 
 .#{$px}-filter-dropdown-menu {
@@ -13,8 +10,6 @@ $dropdown-width: 320px;
   display: flex;
   flex-direction: column;
   padding: $spacing-sm 0;
-
-  // Fixed dropdown width so the menu does not resize based on its content (matches the Sort By dropdown).
   width: $dropdown-width;
 
   &__filters {
@@ -43,10 +38,6 @@ $dropdown-width: 320px;
     justify-content: space-between;
     padding: $spacing-sm $spacing-sm 0 $spacing-sm;
 
-    // CTAs split the available width equally, stay on one line, and centre their label. This
-    // overrides the per-variant button classes (`__buttons`, `__buttons--mobile/--left/--right`),
-    // which otherwise left-pack the label (space-between), force display:block on mobile, or cap
-    // the width at the small-button max-width.
     > .#{$px}-button {
       display: inline-flex;
       flex: 1 1 0;
@@ -97,29 +88,6 @@ $dropdown-width: 320px;
     }
   }
 
-  &__buttons {
-    align-items: center;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-
-    &--left {
-      margin-left: auto;
-      margin-right: 0;
-    }
-
-    &--right {
-      margin-left: 0;
-      margin-right: auto;
-    }
-
-    &--mobile {
-      display: block;
-      margin: $spacing-sm 0 $spacing-md;
-      width: auto;
-    }
-  }
-
   &__button-text {
     color: $white-100;
   }
@@ -163,8 +131,6 @@ $dropdown-width: 320px;
   padding: 0;
 }
 
-// "Filter" drawer (MainFilterDropdown): keep the CTAs anchored to the bottom of the screen
-// while the filter list scrolls, mirroring the live Sale page filter drawer.
 .#{$px}-filter-drawer {
   .#{$px}-filter-drawer-menu {
     flex: 1 1 auto;

--- a/src/patterns/FiltersInline/_filterDropdownMenu.scss
+++ b/src/patterns/FiltersInline/_filterDropdownMenu.scss
@@ -2,14 +2,20 @@
 
 $dropdown-height: 240px;
 
+// Fixed width wide enough for the two footer CTAs (Clear all / Show N) to sit side-by-side on one
+// line, and for long option labels (e.g. "Modern & Contemporary Art") not to wrap.
+$dropdown-width: 320px;
+
 .#{$px}-filter-dropdown-menu {
   background: $white-100;
   border-radius: $radius-sm;
   box-shadow: 0 4px 6px $medium-gray;
   display: flex;
   flex-direction: column;
-  min-width: 100%;
   padding: $spacing-sm 0;
+
+  // Fixed dropdown width so the menu does not resize based on its content (matches the Sort By dropdown).
+  width: $dropdown-width;
 
   &__filters {
     display: flex;
@@ -36,6 +42,21 @@ $dropdown-height: 240px;
     gap: $spacing-sm;
     justify-content: space-between;
     padding: $spacing-sm $spacing-sm 0 $spacing-sm;
+
+    // CTAs split the available width equally, stay on one line, and centre their label. This
+    // overrides the per-variant button classes (`__buttons`, `__buttons--mobile/--left/--right`),
+    // which otherwise left-pack the label (space-between), force display:block on mobile, or cap
+    // the width at the small-button max-width.
+    > .#{$px}-button {
+      display: inline-flex;
+      flex: 1 1 0;
+      justify-content: center;
+      margin: 0;
+      max-width: none;
+      min-width: 0;
+      text-align: center;
+      white-space: nowrap;
+    }
 
     &--drawer {
       box-shadow: 0 -4px 8px -4px $medium-gray;
@@ -94,9 +115,8 @@ $dropdown-height: 240px;
 
     &--mobile {
       display: block;
-      margin-bottom: $spacing-md;
-      margin-top: $spacing-sm;
-      width: 45%;
+      margin: $spacing-sm 0 $spacing-md;
+      width: auto;
     }
   }
 
@@ -141,4 +161,20 @@ $dropdown-height: 240px;
 
 .#{$px}-filter-drawer-mobile {
   padding: 0;
+}
+
+// "Filter" drawer (MainFilterDropdown): keep the CTAs anchored to the bottom of the screen
+// while the filter list scrolls, mirroring the live Sale page filter drawer.
+.#{$px}-filter-drawer {
+  .#{$px}-filter-drawer-menu {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .#{$px}-filter-dropdown-menu__buttons-wrap--drawer {
+    flex: 0 0 auto;
+    margin-top: auto;
+    overflow: visible;
+  }
 }

--- a/src/patterns/FiltersInline/_filterDropdownMenu.scss
+++ b/src/patterns/FiltersInline/_filterDropdownMenu.scss
@@ -62,6 +62,7 @@ $dropdown-width: 320px;
 
   &__mobile-wrap {
     box-shadow: 0 -4px 8px -4px $medium-gray;
+    padding-bottom: calc(#{$spacing-sm} + env(safe-area-inset-bottom));
   }
 
   &__header {
@@ -95,6 +96,7 @@ $dropdown-width: 320px;
   &--mobile {
     border-radius: $radius-sm $radius-sm 0 0;
     box-shadow: none;
+    height: 100%;
     padding: 0;
     width: 100vw;
   }
@@ -128,7 +130,24 @@ $dropdown-width: 320px;
 }
 
 .#{$px}-filter-drawer-mobile {
+  height: min(70dvh, 640px);
   padding: 0;
+
+  .#{$px}-drawer__content {
+    flex: 1 1 auto;
+    height: auto;
+    min-height: 0;
+  }
+
+  .#{$px}-filter-dropdown-menu__filters--mobile {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .#{$px}-filter-dropdown-menu__mobile-wrap {
+    flex: 0 0 auto;
+    margin-top: auto;
+  }
 }
 
 .#{$px}-filter-drawer {

--- a/src/patterns/FiltersInline/_filterDropdownMenu.scss
+++ b/src/patterns/FiltersInline/_filterDropdownMenu.scss
@@ -5,7 +5,7 @@ $dropdown-width: 320px;
 
 .#{$px}-filter-dropdown-menu {
   background: $white-100;
-  border-radius: $radius-sm;
+  border-radius: $radius-xs;
   box-shadow: 0 4px 6px $medium-gray;
   display: flex;
   flex-direction: column;
@@ -94,7 +94,7 @@ $dropdown-width: 320px;
   }
 
   &--mobile {
-    border-radius: $radius-sm $radius-sm 0 0;
+    border-radius: $radius-xs $radius-xs 0 0;
     box-shadow: none;
     height: 100%;
     padding: 0;
@@ -121,7 +121,37 @@ $dropdown-width: 320px;
   }
   .#{$px}-input__input[type='checkbox'] {
     align-self: center;
+    appearance: none;
+    background: $bg-default;
+    border: 1px solid $bg-inverted;
+    border-radius: $radius-xs;
+    display: grid;
+    height: 16px;
+    margin-bottom: 0;
     margin-left: auto;
+    padding: 0;
+    place-content: center;
+    width: 16px;
+
+    &::after {
+      background: $text-inverted;
+      content: '';
+      height: 11px;
+      mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M20 6 9 17l-5-5' fill='none' stroke='black' stroke-linecap='square' stroke-width='2'/%3E%3C/svg%3E");
+      mask-position: center;
+      mask-repeat: no-repeat;
+      mask-size: 16px 11px;
+      opacity: 0;
+      width: 16px;
+    }
+
+    &:checked {
+      background: $bg-inverted;
+
+      &::after {
+        opacity: 1;
+      }
+    }
   }
 }
 
@@ -137,16 +167,24 @@ $dropdown-width: 320px;
     flex: 1 1 auto;
     height: auto;
     min-height: 0;
+    overflow: hidden;
+  }
+
+  .#{$px}-filter-dropdown-menu--mobile {
+    min-height: 0;
+    overflow: hidden;
   }
 
   .#{$px}-filter-dropdown-menu__filters--mobile {
     flex: 1 1 auto;
+    max-height: none;
     min-height: 0;
+    overflow-y: auto;
   }
 
   .#{$px}-filter-dropdown-menu__mobile-wrap {
     flex: 0 0 auto;
-    margin-top: auto;
+    margin-top: 0;
   }
 }
 

--- a/src/patterns/FiltersInline/_filtersInline.scss
+++ b/src/patterns/FiltersInline/_filtersInline.scss
@@ -4,6 +4,28 @@
   display: flex;
   flex-wrap: wrap;
   gap: $spacing-sm;
+
+  // Desktop: align the Sort filter (and anything following it) to the right of the filter row.
+  @include media($breakpoint-md) {
+    > .#{$px}-filters-inline__sort {
+      margin-left: auto;
+    }
+  }
+
+  // Mobile: filter buttons scroll horizontally and overflow off-screen instead of wrapping.
+  @include media($breakpoint-md, 'max') {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    > * {
+      flex: 0 0 auto;
+    }
+  }
 }
 
 .#{$px}-filter-drawer {

--- a/src/patterns/FiltersInline/utils.tsx
+++ b/src/patterns/FiltersInline/utils.tsx
@@ -120,6 +120,20 @@ export const countActiveFilters = (
   return { totalCount, filterCount };
 };
 
+export const hasActiveDimensions = (
+  filters: { id?: string; filterDimensions: Set<FilterDimension> }[] | undefined,
+  buttonType?: string,
+  filterIndex?: number,
+): boolean => {
+  if (!filters) return false;
+
+  const filterDimensions =
+    filters.find((filter) => filter.id === buttonType)?.filterDimensions ??
+    (typeof filterIndex === 'number' ? filters[filterIndex - 1]?.filterDimensions : undefined);
+
+  return filterDimensions ? Array.from(filterDimensions).some((dimension) => dimension.active) : false;
+};
+
 // Helper function to get filter dimensions safely
 export const getFilterDimensions = (
   filters: { filterDimensions: Set<FilterDimension> }[] | undefined,


### PR DESCRIPTION
## Summary
- Update FiltersInline button sizing and disabled Clear all behavior for editorial filters.
- Align desktop sort controls to the right and make mobile filter controls scroll horizontally.
- Widen dropdown/footer CTA layout so labels stay centered and on one line.
- Keep mobile drawer footer actions fully visible with bottom safe-area padding.

## QA
Storybook target: `Patterns/FiltersInline > Playground`

### Desktop width
Click `Departments`.

Expected:
- Before selecting anything, `Clear all` is disabled.
- Selecting `Contemporary Art` enables `Clear all`.
- `Clear all` and `Show 1 Auctions` are equal width, side-by-side, centered, and one line.
- Dropdown stays 320px wide and option labels do not wrap.

### Mobile width
Resize narrow, or use devtools/mobile preview.

Expected:
- Filter buttons stay in one horizontal row and scroll instead of wrapping.
- Clicking `Departments` opens the bottom drawer.
- Selecting `Contemporary Art` keeps the bottom drawer footer buttons side-by-side, one line, and fully visible above the viewport edge.

### Main Filters drawer
Click `Filters`, then select `Contemporary Art`.

Expected:
- Footer stays pinned at the bottom while the filter list scrolls.
- `Show 1 Auctions` remains one line.
- `Clear all` clears the selected filter.

## Validation
- `npm test -- --run src/patterns/FiltersInline/FiltersInline.test.tsx`
- `npx eslint src/patterns/FiltersInline/FilterButton.tsx src/patterns/FiltersInline/FilterDropdownMenuDesktop.tsx src/patterns/FiltersInline/FilterDropdownMenuMobile.tsx src/patterns/FiltersInline/FiltersInline.test.tsx src/patterns/FiltersInline/MainFilterDropdown.tsx src/patterns/FiltersInline/SubFilterDropdown.tsx --max-warnings 0`
- `npx stylelint "src/patterns/FiltersInline/*.scss"`
- `npm run build`