### PR TITLE
feat(Icon): L3-13111 add Card icon

### DIFF
--- a/src/assets/Card.svg
+++ b/src/assets/Card.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M21 17L3 17L3 4C3 3.44772 3.44772 3 4 3L20 3C20.5523 3 21 3.44772 21 4V17ZM19 15L5 15L5 5L19 5V15Z" fill="black"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M3 15L21 15V20C21 20.5523 20.5523 21 20 21L4 21C3.44772 21 3 20.5523 3 20V15ZM5 17L19 17V19L5 19V17Z" fill="black"/>
+</svg>

--- a/src/assets/formatted/Card.tsx
+++ b/src/assets/formatted/Card.tsx
@@ -1,0 +1,55 @@
+import { forwardRef, memo } from 'react';
+import { kebabCase } from 'change-case';
+
+interface CardProps extends React.HTMLAttributes<SVGSVGElement> {
+  color?: string;
+  height?: number | string;
+  width?: number | string;
+  title?: string;
+  titleId?: string;
+}
+
+const Card = memo(
+  forwardRef<SVGSVGElement, CardProps>((inlineProps, ref) => {
+    const { color, height, width, title, titleId: propsTitleId } = inlineProps;
+    const titleId = propsTitleId || kebabCase(title || '');
+    const hasAccessibleName = Boolean(title || inlineProps['aria-label']);
+    const props = hasAccessibleName
+      ? inlineProps
+      : {
+          ...inlineProps,
+          'aria-hidden': true,
+          role: 'presentation',
+        };
+
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        height={height}
+        width={width}
+        role="img"
+        ref={ref}
+        aria-labelledby={titleId}
+        {...props}
+      >
+        {title ? <title id={titleId}>{title}</title> : null}
+        <path
+          fill={color}
+          fillRule="evenodd"
+          d="M21 17H3V4a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1zm-2-2H5V5h14z"
+          clipRule="evenodd"
+        />
+        <path
+          fill={color}
+          fillRule="evenodd"
+          d="M3 15h18v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1zm2 2h14v2H5z"
+          clipRule="evenodd"
+        />
+      </svg>
+    );
+  }),
+);
+
+export default Card;

--- a/src/assets/formatted/index.ts
+++ b/src/assets/formatted/index.ts
@@ -23,6 +23,7 @@ export { default as ArrowRight } from './ArrowRight';
 export { default as ArrowUp } from './ArrowUp';
 export { default as Bag } from './Bag';
 export { default as Calendar } from './Calendar';
+export { default as Card } from './Card';
 export { default as ChevronDown } from './ChevronDown';
 export { default as ChevronLeft } from './ChevronLeft';
 export { default as ChevronRight } from './ChevronRight';


### PR DESCRIPTION
**Jira ticket**

[L3-13111](https://phillipsauctions.atlassian.net/browse/L3-13111)

**Screenshots**
<img width="179" height="196" alt="Screenshot 2026-06-30 at 11 50 54 AM" src="https://github.com/user-attachments/assets/b80d02ea-276e-498d-a156-609d6145bb94" />

**Figma link**

N/A — icon SVG provided directly.

**Summary**

Adds a new `Card` icon to the design system. This follows `src/assets/CONTRIBUTING.md`: the SVG source was added and `npm run icons:format` generated the React component. WHY: the `Card` icon is needed for upcoming UI work tracked under L3-13111, and it should be consumable through the existing `<Icon icon="Card" />` API.

**Change List (describe the changes made to the files)**

- **Add** `src/assets/Card.svg` — the icon source (24×24 viewBox).
- **Add** `src/assets/formatted/Card.tsx` — generated via `npm run icons:format`. Recolorable through the `color` prop (`fill={color}`). Corrected the generated `forwardRef<SVGSVGElement, CardProps>` generic, which the SVGR/Prettier pass had emitted split across lines (invalid TS), to match the convention used by the other icon components.
- **Change** `src/assets/formatted/index.ts` — registered `Card` in the barrel export (alphabetically, between `Calendar` and `ChevronDown`) so it is picked up by the `Icon` component and the Icon Grid story.

**Acceptance Test (how to verify the PR)**

1. Run Storybook (`npm run storybook`).
2. Open the **Icon / Icon Grid** story and confirm a `Card` entry appears.
3. Confirm it is resizable (change `width`/`height`) and recolorable (change `color`).
4. In any consumer: `import { Icon } from '@phillips/seldon'` and render `<Icon icon="Card" />`.

**Regression Test**

- Existing icons are unaffected: `npm run icons:format` uses `--ignore-existing`, so only `Card.tsx` was generated. The barrel change is a single additive export line.

**Evidence of testing**

- `tsc --noEmit`: no `Card`-related errors (only pre-existing unrelated `Carousel` errors).
- `eslint` on `Card.tsx` and `index.ts`: clean (0 warnings).
- `prettier --check src/assets/formatted/Card.tsx`: passes.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [x] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [x] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable — N/A (no class names added)
- [ ] All major areas have a `data-testid` attribute. — N/A (generated icon component)
- [ ] Document all props with jsdoc comments — N/A (generated component follows existing icon convention)
- [ ] All strings should be translatable. — N/A (no strings)
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas. — N/A (icons are rendered/covered via the shared `Icon` component; no per-icon tests exist in this repo)

New Components

- [ ] Are there any accessibility considerations? — Icon a11y is handled by the shared `Icon`/generated wrapper (`role`, `aria-hidden`/`aria-labelledby`, `title` support). No new patterns introduced.
- [ ] Default story called "Playground" — N/A (no new component; surfaces via the existing Icon Grid story)
- [ ] Create a jsdoc comment ... link to the Figma design — N/A
- [x] Export the component ... from the `index.ts` file
- [ ] Import the component scss file into `componentStyles.scss` — N/A (icons have no scss)


[L3-13111]: https://phillipsauctions.atlassian.net/browse/L3-13111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ