### PR TITLE
feat(config): L3-13449 declare package side-effect-free to enable consumer tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "url": "https://github.com/PhillipsAuctionHouse/seldon"
   },
   "type": "module",
+  "sideEffects": [
+    "**/*.scss",
+    "**/*.css"
+  ],
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
**Jira ticket**

[L3-13449](https://phillipsauctions.atlassian.net/browse/L3-13449)

**Screenshots**

N/A it's just bundle size


**Figma link**

N/A

**Summary**

Adds the `sideEffects` field to `package.json` so consumer bundlers (webpack, Rollup, etc.) can tree shake unused Seldon components. Without this field, bundlers must conservatively assume every module in the package has side effects and include the entire library in consumer bundles even when only a few components are imported.

The array form `["**/*.scss", "**/*.css"]` is used instead of `false`: all JS modules are declared side-effect-free (enabling full tree shaking), while style files are explicitly marked as side-effectful. This protects the shipped `dist/scss` files from being pruned if a consumer imports them through their bundler's module graph (e.g. `import '@phillips/seldon/dist/scss/componentStyles.scss'` via sass-loader) rather than the documented Sass `@use`, per the [webpack tree-shaking guidance on CSS files](https://webpack.js.org/guides/tree-shaking/#full-example-understanding-side-effects-with-css-files).

**Change List (describe the changes made to the files)**

- `package.json`: added `"sideEffects": ["**/*.scss", "**/*.css"]`

**Acceptance Test (how to verify the PR)**

- In a consumer app bundled with webpack (production mode), import a single component, e.g. `import { Button } from '@phillips/seldon';`
- Build and inspect the bundle (e.g. with `webpack-bundle-analyzer` or stats output): only the imported component and its dependencies should be included, not the whole library
- Verify styles still work: import `@phillips/seldon/dist/scss/componentStyles.scss` from a JS entry (via sass-loader) and confirm the compiled CSS is present in the production build output

**Regression Test**

- Verify the documented Sass consumption path is unaffected: `@use '@phillips/seldon/dist/scss/componentStyles';` compiles and applies styles as before (Sass resolution bypasses the bundler module graph, so `sideEffects` does not apply to it)

**Evidence of testing**

- Verified the published JS is genuinely side-effect-free with respect to styles: no `.css` files exist in `dist`, and no `import '*.css'`/`'*.scss'` statements exist anywhere in `dist/**/*.js`/`*.cjs` — styles ship exclusively as the copied `dist/scss` tree
- Full unit suite passed via pre-push hook: 81 test files, 232 tests

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[L3-13449]: https://phillipsauctions.atlassian.net/browse/L3-13449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ