### PR TITLE
feat(deps): L3-0000 bundle remaining low-risk dependabot updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13835,9 +13835,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -17013,10 +17013,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },


### PR DESCRIPTION
**Jira ticket**

N/A — dependency housekeeping follow-up to #908.

**Screenshots**
| Before | After |
| ------ | ----- |
| N/A — no runtime UI changes. | Verify via Chromatic diff on this PR. |

**Figma link**

N/A — no design changes.

**Summary**

Follow-up to #908 which merged most of the low-risk dependabot updates. This PR picks up the two transitive bumps that #908 did not resolve because `npm update --package-lock-only` chose not to bump them at that time:

- `picomatch` 2.3.1 → 2.3.2 (source: #840)
- `lodash` 4.17.23 → 4.18.1 (source: #842)

WHY: Same rationale as #908 — bundling low-risk lockfile bumps into one PR reduces per-PR review overhead. Every other PR carrying the `dependency-upgrade-risk:low` label is already satisfied on main at or above its target version (see Change List for the full accounting).

**Change List (describe the changes made to the files)**

`package-lock.json` only — 13-line diff:

- `node_modules/picomatch` 2.3.1 → 2.3.2 (patch bump)
- `node_modules/lodash` 4.17.23 → 4.18.1 (minor bump)

Other low-risk PRs already covered by main (no action needed here, they will be closed as duplicates):

| PR | Package | Target | Main state |
|---|---|---|---|
| #902 | fast-uri | 3.1.4 | 3.1.4 ✅ |
| #900 | immutable | 5.1.9 | 5.1.9 ✅ |
| #898 | svgo | 3.3.4 | 3.3.4 ✅ |
| #897 | linkify-it | 5.0.2 | 5.0.2 ✅ |
| #889 | js-yaml | 4.3.0 | 4.3.0 ✅ |
| #887 | undici | 7.28.0 / 6.27.0 | 7.29.0 / 6.28.0 / 6.27.0 ✅ |
| #873 | qs | 6.15.2 | 6.15.3 ✅ (higher) |
| #844 | follow-redirects | 1.16.0 | 1.16.0 ✅ |
| #842 | @microsoft/api-extractor | 7.58.1 | 7.58.12 ✅ (higher) |
| #839 | lodash-es | 4.18.1 | 4.18.1 ✅ |
| #837 | handlebars | 4.7.9 | 4.7.9 ✅ |
| #832 | flatted | 3.4.2 | 3.4.3 ✅ (higher) |
| #824 | tar + npm | 11.12.1 | 11.18.0 ✅ (higher) |
| #819 | dompurify + @types/dompurify | 3.3.1 / 3.2.0 | 3.4.12 in #908; stub removed in #908 |
| #811 | react-zoom-pan-pinch | 3.7.0 | 3.7.0 ✅ |
| #809 | prettier | 3.8.1 | 3.8.1 ✅ |

**Acceptance Test (how to verify the PR)**

1. CI on this PR passes (build + lint + unit tests + Chromatic).
2. Review the Chromatic diff — no visual regressions expected (both bumps are transitive).
3. After merge, dependabot will auto-close #840 and #842 once main catches up; close the 15 fully-applied PRs manually or via bot.

**Regression Test**

- `picomatch` is used by glob/vite/vitest/rollup toolchain — CI running here exercises all of them. If build and tests pass here, downstream consumers are unaffected.
- `lodash` is used only transitively by `@microsoft/api-extractor` (see PR #842). Not imported by anything in `src/`.

**Evidence of testing**

- `npm ci` → clean install
- `npm run build` → exit 0
- `npm run lint` → exit 0 (tsc --noEmit, eslint, stylelint, markdownlint)
- `npx vitest run --project=unit` → **1042 / 1042** tests passing

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)