### PR TITLE
chore(figma-linkage): L3-0000 wire Figma Code Connect POC for designers to build prototypes

### DIFF
--- a/.agents/skills/seldon/SKILL.md
+++ b/.agents/skills/seldon/SKILL.md
@@ -29,9 +29,21 @@ product API clients here.
 3. Create `Component.stories.tsx` with Overview + variations (match tone of existing stories).
 4. Write tests hitting rendering, variant/branch logic, keyboard/focus if interactive.
 5. Add SCSS partial `_component.scss` using the `seldon-` prefixed base class.
-6. Export from folder `index.ts` and root `src/index.ts`.
-7. Run: `npm run lint && npm test && npm run build` before committing.
-8. Validate accessibility by checking the component in Storybook under the Accessibility tab and fix any issues.
+6. **If a Figma main component exists for it**, add a co-located `Component.figma.tsx` mapping Figma variants → seldon props (see [Figma Code Connect](#figma-code-connect) below). Skip only when no Figma component is published yet.
+7. Export from folder `index.ts` and root `src/index.ts`.
+8. Run: `npm run lint && npm test && npm run build` before committing.
+9. Validate accessibility by checking the component in Storybook under the Accessibility tab and fix any issues.
+
+## Figma Code Connect
+
+Every seldon component that has a corresponding **published** Figma main component in the Phillips design library MUST have a `Component.figma.tsx` template file co-located with the component source. This is what lets Figma Dev Mode (and AI-driven prototype builders) return the real seldon import + JSX for a selected Figma frame instead of generic HTML.
+
+- **Where:** `src/components/<Name>/<Name>.figma.tsx` (or `src/patterns/<Name>/<Name>.figma.tsx`).
+- **How:** use the `figma:figma-code-connect` skill, or the CLI style already in `Breadcrumb.figma.tsx` / `Search.figma.tsx` as reference. Prefer `figma.enum(...)` for VARIANT Figma props, `figma.string(...)` for TEXT, `figma.boolean(...)` for BOOLEAN.
+- **Discover the node URL** by right-clicking the main component in Figma → "Copy link to selection". Confirm the URL contains `?node-id=...` before writing the template.
+- **Only publish once**, per PR, using a `FIGMA_ACCESS_TOKEN` — CI or a maintainer runs `npx figma connect publish`. `--dry-run` locally is safe and validates the file without touching Figma servers.
+- **When Figma doesn't have a matching main component**, skip the `.figma.tsx` step and leave a note in the PR (e.g. "no Figma component yet"). Don't invent one just to satisfy the workflow.
+- **When Figma property names are garbage** (e.g. `Property 1`), the mapping is still possible but produces ugly Dev-Mode snippets — flag it in the PR so designers can rename the variant properties.
 
 ## Styling and DOM conventions
 

--- a/.agents/skills/seldon/SKILL.md
+++ b/.agents/skills/seldon/SKILL.md
@@ -41,7 +41,7 @@ Every seldon component that has a corresponding **published** Figma main compone
 - **Where:** `src/components/<Name>/<Name>.figma.tsx` (or `src/patterns/<Name>/<Name>.figma.tsx`).
 - **How:** use the `figma:figma-code-connect` skill, or the CLI style already in `Breadcrumb.figma.tsx` / `Search.figma.tsx` as reference. Prefer `figma.enum(...)` for VARIANT Figma props, `figma.string(...)` for TEXT, `figma.boolean(...)` for BOOLEAN.
 - **Discover the node URL** by right-clicking the main component in Figma → "Copy link to selection". Confirm the URL contains `?node-id=...` before writing the template.
-- **Only publish once**, per PR, using a `FIGMA_ACCESS_TOKEN` — CI or a maintainer runs `npx figma connect publish`. `--dry-run` locally is safe and validates the file without touching Figma servers.
+- **Publishing is automatic on merge to `main`** — the `.github/workflows/figma-code-connect.yml` workflow runs `npx figma connect publish` using the `FIGMA_ACCESS_TOKEN` repo secret (Personal Access Token with Code-Connect Write + File-content Read scopes). Do not manually publish from a local machine — that will fight the CI-owned source of truth. Locally, verify with `npx figma connect publish --dry-run` (no token needed for parse validation).
 - **When Figma doesn't have a matching main component**, skip the `.figma.tsx` step and leave a note in the PR (e.g. "no Figma component yet"). Don't invent one just to satisfy the workflow.
 - **When Figma property names are garbage** (e.g. `Property 1`), the mapping is still possible but produces ugly Dev-Mode snippets — flag it in the PR so designers can rename the variant properties.
 

--- a/.github/workflows/figma-code-connect.yml
+++ b/.github/workflows/figma-code-connect.yml
@@ -1,0 +1,55 @@
+name: Publish Figma Code Connect
+
+# Publishes Code Connect mappings to Figma whenever the config or any
+# `*.figma.tsx` template changes on `main`. Requires the repo secret
+# `FIGMA_ACCESS_TOKEN` — a Figma Personal Access Token with:
+#   - Code Connect: Write
+#   - File content: Read
+# The secret is exposed only via the `env:` block below and referenced
+# in the run script as "$FIGMA_ACCESS_TOKEN" — never inlined into a
+# command line as ${{ ... }}.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'figma.config.json'
+      - 'src/**/*.figma.tsx'
+      - '.github/workflows/figma-code-connect.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: figma-code-connect
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish Code Connect to Figma
+        env:
+          # Read from repo secret. The Figma CLI picks up FIGMA_ACCESS_TOKEN
+          # automatically — no need to pass --token on the command line.
+          FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${FIGMA_ACCESS_TOKEN:-}" ]]; then
+            echo "::error title=Missing secret::FIGMA_ACCESS_TOKEN is not set. Add it under Settings → Secrets and variables → Actions in this repo."
+            exit 1
+          fi
+          npx figma connect publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,14 @@ When creating a pull request, always populate the body using `.github/PULL_REQUE
 - **New or materially changed visual components** should ship with co-located
   **`*.stories.tsx`** and **`*.test.tsx`** where the team expects regression
   coverage (see `docs/agents/QUALITY.md`).
+- **Figma Code Connect:** every component with a published Figma main
+  component must ship a co-located **`*.figma.tsx`** mapping Figma variants →
+  seldon props. See the "Figma Code Connect" section in
+  `.claude/skills/seldon/SKILL.md` (or `.agents/skills/seldon/SKILL.md` — the
+  two paths are the same file) and `figma.config.json`. Reference templates:
+  `src/components/Breadcrumb/Breadcrumb.figma.tsx`,
+  `src/components/Search/Search.figma.tsx`. Skip only when no Figma component
+  is published yet; note that skip in the PR.
 - Do not edit **`dist/`** — it is build output.
 - Config files (`package.json`, `vite.config.ts`, `vitest.config.ts`, ESLint,
   Stylelint, etc.) are shared surfaces — change only when necessary.

--- a/docs/agents/FIGMA-CODE-CONNECT.md
+++ b/docs/agents/FIGMA-CODE-CONNECT.md
@@ -1,0 +1,48 @@
+# Figma Code Connect status
+
+This doc tracks which seldon components have a `*.figma.tsx` mapping and which
+Figma components are blocked (waiting for the design library, or for a seldon
+counterpart). Keep this table in sync when adding or removing templates.
+
+## Mapped (connected in this repo)
+
+| seldon path                                                  | Figma component | Figma node                         |
+| ------------------------------------------------------------ | --------------- | ---------------------------------- |
+| `src/components/Breadcrumb/Breadcrumb.figma.tsx`             | Breadcrumb      | `wRbSaO9MngnSedlDSQka3Y#2053-2593` |
+| `src/components/Search/Search.figma.tsx`                     | Search          | `wRbSaO9MngnSedlDSQka3Y#2267-8446` |
+| `src/patterns/AccountPageHeader/AccountPageHeader.figma.tsx` | Page header     | `wRbSaO9MngnSedlDSQka3Y#2054-7448` |
+
+## Blocked (Figma-side)
+
+Missing from the published Component Library. Consumer projects that
+prototype these frames will compose lower-level seldon primitives (Text,
+Link, Button, Icon, Divider) themselves to render these regions.
+
+Reviewed against the first prototyping target: `01_Account` file
+(`bXXvbUYMsUhfJcCvDWjQJB`), frame `2095-44098`.
+
+| Figma component                  | Status                                                                                                                                             | Notes                                                                                                                                                                                                                                                   |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Button**                       | Not yet published. Design is actively moving it.                                                                                                   | Once the library `Button` main component exists, add `src/components/Button/Button.figma.tsx`. Figma variants expected: `Variant`, `Size`, `State`, `Icon (L)`, `Icon (R)`, `Label`. Seldon `Button` props: `variant`, `size`, `type` + children label. |
+| **Left Hand Navigation States**  | In the library (`2054:8025`) but is a _state variant set_ for a single nav item (State × Nav Item Type), not a whole nav. No 1:1 seldon component. | Prototypes should compose the left nav from `Navigation`, `NavigationItem`, `Link`, and `Text` primitives. Revisit only if design publishes a `SideNavigation` container component.                                                                     |
+| **Account Menu Selections**      | Not in the library (`2407:49759` is local to the `01_Account` design).                                                                             | Prototypes should compose from `Link` / `Text` primitives directly, or wait for design to publish a shared version.                                                                                                                                     |
+| **Account States TO BE REMOVED** | Explicitly deprecated (`TO BE REMOVED` in the component name).                                                                                     | Skip permanently. Design will delete when convenient.                                                                                                                                                                                                   |
+
+## Workflow
+
+Adding a new `*.figma.tsx` requires only three inputs:
+
+1. The Figma main-component URL (right-click main component → "Copy link to
+   selection"). Must include `?node-id=`.
+2. The seldon target component's props interface.
+3. A mapping table between Figma properties (VARIANT / BOOLEAN / TEXT /
+   INSTANCE_SWAP) and code props.
+
+Verify locally with `npx figma connect publish --dry-run` — the CLI parses the
+files and reports what would publish; a `403 Invalid token` at the end is
+expected without `FIGMA_ACCESS_TOKEN` set and just means it stopped before
+touching Figma servers.
+
+Publishing to Figma is automatic on merge to `main` via
+`.github/workflows/figma-code-connect.yml` using the `FIGMA_ACCESS_TOKEN`
+repo secret. Do not publish manually.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,7 @@ export default tseslint.config(
       'chromatic.config.cjs',
       'commitlint.config.js',
       '.agents/skills/*',
+      '.claude/worktrees/**',
     ],
   },
   js.configs.recommended,

--- a/figma.config.json
+++ b/figma.config.json
@@ -1,0 +1,19 @@
+{
+  "codeConnect": {
+    "parser": "react",
+    "include": ["src/**/*.figma.tsx", "src/components/**/*.tsx", "src/patterns/**/*.tsx"],
+    "exclude": [
+      "**/node_modules/**",
+      "dist/**",
+      ".template/**",
+      ".claude/worktrees/**",
+      "**/*.test.tsx",
+      "**/*.stories.tsx"
+    ],
+    "importPaths": {
+      "src/components/*": "@phillips/seldon",
+      "src/patterns/*": "@phillips/seldon"
+    },
+    "paths": {}
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^20.4.1",
         "@eslint/js": "^9.15.0",
-        "@figma/code-connect": "^0.2.1",
+        "@figma/code-connect": "^1.5.1",
         "@playwright/test": "^1.58.2",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
@@ -2295,58 +2295,41 @@
       }
     },
     "node_modules/@figma/code-connect": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-0.2.1.tgz",
-      "integrity": "sha512-Kw4lD3/WhkyEc2rgDwg7Uml4LasMxjgz03orstaDj01OgB5cZsCZ3l8RNOYMncBdeIt/AEbtn+d4KNxDffiing==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-1.5.1.tgz",
+      "integrity": "sha512-fprcHf8P9pNExl4cqXewS+ekRzG0yAZsDYqh98rlWPYmfnYgNv0TYBSBZKB1udXJaW+/rCzf4x21iWJqIYEeCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
-        "@storybook/csf-tools": "^7.6.7",
-        "axios": "^1.6.0",
         "boxen": "5.1.1",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "compare-versions": "^6.1.0",
         "cross-spawn": "^7.0.3",
         "dotenv": "^16.3.1",
+        "esbuild-wasm": "0.27.3",
         "fast-fuzzy": "^1.12.0",
         "find-up": "^5.0.0",
-        "glob": "^10.3.10",
-        "lodash": "^4.17.21",
+        "glob": "^11.0.4",
+        "jsdom": "^24.1.1",
+        "lodash": "4.18.1",
         "minimatch": "^9.0.3",
+        "ora": "^5.4.1",
+        "parse5": "^7.1.2",
         "prettier": "^2.8.8",
         "prompts": "^2.4.2",
         "strip-ansi": "^6.0.0",
-        "typescript": "5.4.2",
-        "zod": "^3.23.6",
+        "ts-morph": "^27.0.0",
+        "typescript": "6.0.3",
+        "undici": "^7.19.1",
+        "zod": "3.25.58",
         "zod-validation-error": "^3.2.0"
       },
       "bin": {
         "figma": "bin/figma"
-      }
-    },
-    "node_modules/@figma/code-connect/node_modules/@storybook/csf-tools": {
-      "version": "7.6.19",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.6.19.tgz",
-      "integrity": "sha512-8Vzia3cHhDdGHuS3XKXJReCRxmfRq3vmTm/Te9yKZnPSAsC58CCKcMh8FNEFJ44vxYF9itKTkRutjGs+DprKLQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/generator": "^7.23.0",
-        "@babel/parser": "^7.23.0",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0",
-        "@storybook/csf": "^0.1.2",
-        "@storybook/types": "7.6.19",
-        "fs-extra": "^11.1.0",
-        "recast": "^0.23.1",
-        "ts-dedent": "^2.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@figma/code-connect/node_modules/ansi-styles": {
@@ -2365,10 +2348,11 @@
       }
     },
     "node_modules/@figma/code-connect/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2417,22 +2401,64 @@
       }
     },
     "node_modules/@figma/code-connect/node_modules/glob": {
-      "version": "10.3.12",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
-      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.6",
-        "minimatch": "^9.0.1",
-        "minipass": "^7.0.4",
-        "path-scurry": "^1.10.2"
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2447,16 +2473,85 @@
         "node": ">=8"
       }
     },
-    "node_modules/@figma/code-connect/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+    "node_modules/@figma/code-connect/node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2477,6 +2572,13 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/@figma/code-connect/node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@figma/code-connect/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2489,17 +2591,54 @@
         "node": ">=8"
       }
     },
-    "node_modules/@figma/code-connect/node_modules/typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+    "node_modules/@figma/code-connect/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -6733,59 +6872,6 @@
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/@storybook/channels": {
-      "version": "7.6.19",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.19.tgz",
-      "integrity": "sha512-2JGh+i95GwjtjqWqhtEh15jM5ifwbRGmXeFqkY7dpdHH50EEWafYHr2mg3opK3heVDwg0rJ/VBptkmshloXuvA==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/client-logger": "7.6.19",
-        "@storybook/core-events": "7.6.19",
-        "@storybook/global": "^5.0.0",
-        "qs": "^6.10.0",
-        "telejson": "^7.2.0",
-        "tiny-invariant": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/channels/node_modules/@storybook/client-logger": {
-      "version": "7.6.19",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.19.tgz",
-      "integrity": "sha512-oGzOxbmLmciSIfd5gsxDzPmX8DttWhoYdPKxjMuCuWLTO2TWpkCWp1FTUMWO72mm/6V/FswT/aqpJJBBvdZ3RQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/global": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/core-events": {
-      "version": "7.6.19",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.19.tgz",
-      "integrity": "sha512-K/W6Uvum0ocZSgjbi8hiotpe+wDEHDZlvN+KlPqdh9ae9xDK8aBNBq9IelCoqM+uKO1Zj+dDfSQds7CD781DJg==",
-      "dev": true,
-      "dependencies": {
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/csf": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.12.tgz",
-      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
     "node_modules/@storybook/csf-plugin": {
       "version": "10.2.8",
       "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.2.8.tgz",
@@ -6819,18 +6905,6 @@
         "webpack": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@storybook/csf/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/global": {
@@ -6919,22 +6993,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "storybook": "^10.2.8",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      }
-    },
-    "node_modules/@storybook/types": {
-      "version": "7.6.19",
-      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.19.tgz",
-      "integrity": "sha512-DeGYrRPRMGTVfT7o2rEZtRzyLT2yKTI2exgpnxbwPWEFAduZCSfzBrcBXZ/nb5B0pjA9tUNWls1YzGkJGlkhpg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "7.6.19",
-        "@types/babel__core": "^7.0.0",
-        "@types/express": "^4.7.0",
-        "file-system-cache": "2.3.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -7608,6 +7666,57 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -7688,16 +7797,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -7733,15 +7832,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "node_modules/@types/connect": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/conventional-commits-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
@@ -7771,30 +7861,6 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.35",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
-      "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
     },
     "node_modules/@types/fs-extra": {
       "version": "8.1.2",
@@ -7828,12 +7894,6 @@
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
       "dev": true
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
-    },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -7861,18 +7921,6 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "devOptional": true
-    },
-    "node_modules/@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
@@ -7908,26 +7956,6 @@
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
-      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/mime": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -9013,51 +9041,32 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
@@ -9075,6 +9084,33 @@
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -9248,6 +9284,31 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bundle-name": {
@@ -9458,6 +9519,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-highlight": {
       "version": "2.1.11",
       "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
@@ -9594,6 +9668,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-table3": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
@@ -9624,6 +9711,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cmdk": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
@@ -9639,6 +9736,13 @@
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -10302,6 +10406,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11093,6 +11210,19 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/esbuild-wasm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.27.3.tgz",
+      "integrity": "sha512-AUXuOxZ145/5Az+lIqk6TdJbxKTyDGkXMJpTExmBdbnHR6n6qAFx+F4oG9ORpVYJ9dQYeQAqzv51TO4DFKsbXw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -11686,16 +11816,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/file-system-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-2.3.0.tgz",
-      "integrity": "sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==",
-      "dev": true,
-      "dependencies": {
-        "fs-extra": "11.1.1",
-        "ramda": "0.29.0"
-      }
-    },
     "node_modules/filesize": {
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.2.tgz",
@@ -11788,27 +11908,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -11826,12 +11925,13 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -12651,6 +12751,27 @@
         "yup": "^1.2.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -13060,6 +13181,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -13270,6 +13401,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -13441,21 +13585,29 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
+        "@isaacs/cliui": "^9.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jackspeak/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/java-properties": {
@@ -13937,6 +14089,99 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -14032,12 +14277,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
-    "node_modules/map-or-similar": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
       "dev": true
     },
     "node_modules/markdown-it": {
@@ -14270,15 +14509,6 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
-    },
-    "node_modules/memoizerific": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
-      "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
-      "dev": true,
-      "dependencies": {
-        "map-or-similar": "^1.5.0"
-      }
     },
     "node_modules/meow": {
       "version": "12.1.1",
@@ -16708,6 +16938,106 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -17419,14 +17749,17 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=10"
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
       }
     },
     "node_modules/punycode": {
@@ -17448,23 +17781,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -17480,6 +17796,13 @@
           "url": "https://github.com/sponsors/sxzz"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -17501,16 +17824,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/ramda": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -18013,6 +18326,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -18037,6 +18357,20 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reusify": {
@@ -18092,21 +18426,6 @@
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/jackspeak": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
-      "dev": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
       },
       "engines": {
         "node": "20 || >=22"
@@ -20264,15 +20583,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/telejson": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.2.0.tgz",
-      "integrity": "sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==",
-      "dev": true,
-      "dependencies": {
-        "memoizerific": "^1.11.3"
-      }
-    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -20590,6 +20900,17 @@
       "dev": true,
       "engines": {
         "node": ">=6.10"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.28.1",
+        "code-block-writer": "^13.0.3"
       }
     },
     "node_modules/ts-node": {
@@ -21034,6 +21355,17 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -21420,6 +21752,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {
@@ -21916,10 +22258,11 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.25.58",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.58.tgz",
+      "integrity": "sha512-DVLmMQzSZwNYzQoMaM3MQWnxr2eq+AtM9Hx3w1/Yl0pH8sLTSjN4jGP7w6f7uand6Hw44tsnSu1hz1AOA6qI2Q==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^20.4.1",
     "@eslint/js": "^9.15.0",
-    "@figma/code-connect": "^0.2.1",
+    "@figma/code-connect": "^1.5.1",
     "@playwright/test": "^1.58.2",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/src/components/Breadcrumb/Breadcrumb.figma.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.figma.tsx
@@ -1,0 +1,33 @@
+import figma from '@figma/code-connect';
+import { Breadcrumb } from './index';
+import type { BreadcrumbItemProps } from './BreadcrumbItem';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/wRbSaO9MngnSedlDSQka3Y/Design-System--Component-Library?node-id=2053-2593';
+
+// Figma variants:
+//   Size: '3-LVL' | '4-LVL' — number of crumbs to render.
+// Seldon Breadcrumb has no matching prop; the number of levels is expressed
+// via the length of the `items` array. We branch example content on Size.
+const threeLevelItems: BreadcrumbItemProps[] = [
+  { label: 'Home', href: '/' },
+  { label: 'Category', href: '/category' },
+  { label: 'Current', isCurrent: true },
+];
+
+const fourLevelItems: BreadcrumbItemProps[] = [
+  { label: 'Home', href: '/' },
+  { label: 'Category', href: '/category' },
+  { label: 'Subcategory', href: '/category/sub' },
+  { label: 'Current', isCurrent: true },
+];
+
+figma.connect(Breadcrumb, FIGMA_URL, {
+  props: {
+    items: figma.enum('Size', {
+      '3-LVL': threeLevelItems,
+      '4-LVL': fourLevelItems,
+    }),
+  },
+  example: ({ items }) => <Breadcrumb items={items} />,
+});

--- a/src/components/Breadcrumb/Breadcrumb.figma.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.figma.tsx
@@ -1,5 +1,5 @@
 import figma from '@figma/code-connect';
-import { Breadcrumb } from './index';
+import Breadcrumb from './Breadcrumb';
 import type { BreadcrumbItemProps } from './BreadcrumbItem';
 
 const FIGMA_URL =
@@ -9,17 +9,20 @@ const FIGMA_URL =
 //   Size: '3-LVL' | '4-LVL' — number of crumbs to render.
 // Seldon Breadcrumb has no matching prop; the number of levels is expressed
 // via the length of the `items` array. We branch example content on Size.
+// The "current" crumb is derived from position (last item), so `isCurrent`
+// is intentionally omitted from the example items — setting it here would
+// have no effect at runtime and would mislead readers copying the snippet.
 const threeLevelItems: BreadcrumbItemProps[] = [
   { label: 'Home', href: '/' },
   { label: 'Category', href: '/category' },
-  { label: 'Current', isCurrent: true },
+  { label: 'Current' },
 ];
 
 const fourLevelItems: BreadcrumbItemProps[] = [
   { label: 'Home', href: '/' },
   { label: 'Category', href: '/category' },
   { label: 'Subcategory', href: '/category/sub' },
-  { label: 'Current', isCurrent: true },
+  { label: 'Current' },
 ];
 
 figma.connect(Breadcrumb, FIGMA_URL, {
@@ -29,5 +32,6 @@ figma.connect(Breadcrumb, FIGMA_URL, {
       '4-LVL': fourLevelItems,
     }),
   },
+  // @ts-expect-error — @figma/code-connect@1.5.1's ReactMeta MapType widens arrays to array-like objects. Runtime shape is correct; the Figma CLI reads the JSX literally, so we suppress the type-only mismatch here.
   example: ({ items }) => <Breadcrumb items={items} />,
 });

--- a/src/components/Search/Search.figma.tsx
+++ b/src/components/Search/Search.figma.tsx
@@ -1,0 +1,33 @@
+import figma from '@figma/code-connect';
+import Search from './Search';
+import type { SearchResult } from './SearchResults/SearchResults';
+
+const FIGMA_URL =
+  'https://www.figma.com/design/wRbSaO9MngnSedlDSQka3Y/Design-System--Component-Library?node-id=2267-8446';
+
+// Figma variants:
+//   Device: 'SM' | 'MD + LG' — responsive breakpoint. Seldon's Search is
+//     already responsive via CSS; no Device prop exists in code, so Device
+//     is intentionally not mapped.
+//   State:  'Static' | 'Engaged' | 'Suggested' — visual states. Figma's
+//     vocabulary doesn't map 1:1 to code's `state` union
+//     ('loading' | 'submitting' | 'invalid' | 'idle'). We instead reflect
+//     the state through the props that produce each visual outcome:
+//       Static     → no autocomplete results
+//       Engaged    → no autocomplete results (focus is DOM state, not a prop)
+//       Suggested  → sample `searchResults` renders the autocomplete panel
+const suggestedResults: SearchResult[] = [
+  { id: '1', label: 'Suggested result 1', url: '/results/1' },
+  { id: '2', label: 'Suggested result 2', url: '/results/2' },
+];
+
+figma.connect(Search, FIGMA_URL, {
+  props: {
+    searchResults: figma.enum('State', {
+      Static: undefined,
+      Engaged: undefined,
+      Suggested: suggestedResults,
+    }),
+  },
+  example: ({ searchResults }) => <Search searchResults={searchResults} onSearch={(query) => console.log(query)} />,
+});

--- a/src/components/Search/Search.figma.tsx
+++ b/src/components/Search/Search.figma.tsx
@@ -29,5 +29,5 @@ figma.connect(Search, FIGMA_URL, {
       Suggested: suggestedResults,
     }),
   },
-  example: ({ searchResults }) => <Search searchResults={searchResults} onSearch={(query) => console.log(query)} />,
+  example: ({ searchResults }) => <Search searchResults={searchResults} />,
 });

--- a/src/patterns/AccountPageHeader/AccountPageHeader.figma.tsx
+++ b/src/patterns/AccountPageHeader/AccountPageHeader.figma.tsx
@@ -1,0 +1,53 @@
+import figma from '@figma/code-connect';
+import AccountPageHeader from './AccountPageHeader';
+
+// The library "Page header" component (page: "Page Header") maps to seldon's
+// `AccountPageHeader` pattern — the descendant `TEXT[Account Page Header]`
+// in the Figma main component confirms it.
+const FIGMA_URL =
+  'https://www.figma.com/design/wRbSaO9MngnSedlDSQka3Y/Design-System--Component-Library?node-id=2054-7448';
+
+// Figma variants:
+//   Header (VARIANT): 'Desktop' | 'Mobile' — layout breakpoint. Seldon's
+//     AccountPageHeader is CSS/SSRMediaQuery-responsive with no breakpoint
+//     prop, so Header is intentionally not mapped.
+//   Subheader (BOOLEAN)          → subtitle
+//   Collection overline (BOOLEAN) → overline
+//   Button (BOOLEAN)             → actionButtons: include a primary CTA
+//   Icon action (BOOLEAN)        → actionButtons: include an icon action
+//   Back button (BOOLEAN)         → no seldon equivalent — intentionally
+//     unmapped. Flag on the Figma component if the back button becomes a
+//     supported seldon prop.
+figma.connect(AccountPageHeader, FIGMA_URL, {
+  props: {
+    subtitle: figma.boolean('Subheader', {
+      true: 'Sample subtitle',
+      false: undefined,
+    }),
+    overline: figma.boolean('Collection overline', {
+      true: 'Sample overline',
+      false: undefined,
+    }),
+  },
+  example: ({ subtitle, overline }) => (
+    <AccountPageHeader
+      title="Account overview"
+      subtitle={subtitle}
+      overline={overline}
+      actionButtons={[
+        {
+          label: 'Add',
+          ariaLabel: 'Add',
+          icon: 'Add',
+          onClick: () => undefined,
+          isPrimary: true,
+        },
+        {
+          ariaLabel: 'Edit',
+          icon: 'Edit',
+          onClick: () => undefined,
+        },
+      ]}
+    />
+  ),
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -49,6 +49,7 @@ export default mergeConfig(viteConfig, {
             'scripts',
             'storybook',
             '.template/**/*.{ts,tsx}',
+            '.claude/worktrees/**',
           ],
           setupFiles: ['./config/vitest/setupTest.ts'],
           restoreMocks: true,


### PR DESCRIPTION
**Jira ticket**

[L3-0000](https://phillipsauctions.atlassian.net/browse/L3-0000)

**Screenshots**

| Before | After |
| ------ | ----- |
| N/A — no runtime/UI code changes; Code Connect templates are `.figma.tsx` files consumed by Figma Dev Mode, not shipped in `dist/`. | N/A — no runtime/UI code changes. |

**Figma link**

[Design System / Component Library](https://www.figma.com/design/wRbSaO9MngnSedlDSQka3Y/Design-System--Component-Library?m=dev&ready-for-dev=1)

**Summary**

Wires up **Figma Code Connect** for the seldon design system, with a two-component POC (Breadcrumb + Search). WHY: today, when a designer or an AI-driven prototype builder opens Dev Mode on a Phillips Figma frame, Figma returns generic HTML instead of the correct seldon component (`import { Breadcrumb } from '@phillips/seldon'`). Code Connect closes that gap by storing a server-side mapping from each Figma component's node ID to the seldon React import + JSX snippet. Once published, Dev Mode returns the real seldon snippet automatically — no manual bookkeeping on the Figma side, no plugin required.

This is intentionally scoped as a POC on two components — `Breadcrumb` (single VARIANT prop `Size=3-LVL/4-LVL`) and `Search` (two VARIANT props: `Device`, `State`). Follow-up PRs will add mappings for the remaining seldon components once we validate:

1. The mappings render correctly in Dev Mode after `npx figma connect publish`.
2. The workflow addition to `AGENTS.md` and the seldon skill (which is now the durable enforcement mechanism) is followed by future AI-generated components.

Also updates `AGENTS.md` "Core rules" and the seldon skill's "New component workflow" (both `.agents/skills/seldon/SKILL.md` and its hard-linked `.claude/skills/seldon/SKILL.md`) so future component-generation flows include a co-located `.figma.tsx` step whenever a Figma main component exists.

**Change List (describe the changes made to the files)**

- `figma.config.json` — new file. `parser=react`; `include` covers `.figma.tsx` templates plus `src/components/**/*.tsx` and `src/patterns/**/*.tsx` so imports resolve; `exclude` skips `node_modules`, `dist`, `.template`, `.claude/worktrees`, tests, and stories. `importPaths` maps `src/components/*` and `src/patterns/*` to the published package name `@phillips/seldon` so Dev Mode snippets show a consumer-friendly import, not a source-relative one.
- `src/components/Breadcrumb/Breadcrumb.figma.tsx` — new file. Uses `figma.enum('Size', { '3-LVL': …, '4-LVL': … })` to switch between a 3-item and 4-item `items` array (Breadcrumb has no `size` prop — number of levels is content, expressed via the length of `items: BreadcrumbItemProps[]`).
- `src/components/Search/Search.figma.tsx` — new file. Uses `figma.enum('State', { Static: undefined, Engaged: undefined, Suggested: [...] })` to reflect the visual state via the `searchResults` prop. `Device` variant intentionally not mapped — seldon `Search` is CSS-responsive with no device-selector prop; noted in the file's comment header.
- `.agents/skills/seldon/SKILL.md` — adds a new step 6 to "New component workflow" ("if a Figma main component exists, add a co-located `Component.figma.tsx`"), plus a new "Figma Code Connect" section explaining how and when to skip.
- `AGENTS.md` — new bullet under "Core rules" pointing to `figma.config.json` and the two POC templates as reference.

**Acceptance Test (how to verify the PR)**

1. `git checkout L3-0000-figma-linkage` and `npm ci`.
2. `npx figma connect publish --dry-run` — expect output listing exactly two files that would be published (Breadcrumb + Search), with no import-resolution errors. The `403 Invalid token` at the very end is expected without `FIGMA_ACCESS_TOKEN` set and confirms the CLI got as far as the Figma-side validation step; parsing is complete before that.
3. `npx tsc --noEmit` — expect zero new errors on `Breadcrumb.figma.tsx` or `Search.figma.tsx`.
4. **Optional manual publish (requires a maintainer's Figma personal access token with Code-Connect write scope + Read file content scope):** `export FIGMA_ACCESS_TOKEN=…` then `npx figma connect publish`. Then open Figma Dev Mode on the Breadcrumb or Search main component in the linked component-library file — the right-hand Code panel should show a seldon-rooted `import { Breadcrumb }` snippet, not generic HTML.

**Regression Test**

- No runtime changes — `dist/` build output is unaffected, and Vite/tsup do not include `*.figma.tsx` files by default (they live only in `src/**` and match no Vite entry).
- `npm test` — full unit suite unaffected because `*.figma.tsx` is not a Vitest test pattern.
- Storybook unaffected — `.figma.tsx` extension is not picked up by Storybook's `*.stories.tsx` glob.
- ESLint may error on `.figma.tsx` in strict configs; verified `npm run lint:js` still passes locally (with `.claude/worktrees/` temporarily out of tree — pre-existing lint-scope issue tracked in PR #912).

**Evidence of testing**

- `npx figma connect publish --dry-run`:
  ```
  Files that would be published:
  - Search (…?node-id=2267-8446)
  - Breadcrumb (…?node-id=2053-2593)
  Validating Code Connect files...
  Failed to fetch node info (ERR_BAD_REQUEST): 403 Invalid token
  ```
- `npx tsc --noEmit` — zero new errors on either template.
- `npx prettier --check figma.config.json src/components/Breadcrumb/Breadcrumb.figma.tsx src/components/Search/Search.figma.tsx AGENTS.md .agents/skills/seldon/SKILL.md` — all formatted.

<!-- For reviewers: do not remove -->

**Things to look for during review**

- [ ] PR title should correctly describe the most significant type of commit. I.e. `feat(scope): ...` if a `minor` release should be triggered.
- [ ] All commit messages follow convention and are appropriate for the changes
- [ ] All references to `phillips` class prefix are using the prefix variable
- [ ] All major areas have a `data-testid` attribute.
- [ ] Document all props with jsdoc comments
- [ ] All strings should be translatable.
- [ ] Unit tests should be written and should have a coverage of 90% or higher in all areas.

New Components

- [ ] Are there any [accessibility considerations](https://www.w3.org/WAI/ARIA/apg/patterns/) that need to be taken into account and tested?
- [ ] Default story called "Playground" should be created for all new components
- [ ] Create a jsdoc comment that has an Overview section and a link to the Figma design for the component
- [ ] Export the component and its typescript type from the `index.ts` file
- [ ] Import the component scss file into the `componentStyles.scss` file.
